### PR TITLE
Add Linux fullscreen support

### DIFF
--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -114,7 +114,7 @@ ultramodern::WindowHandle create_window(ultramodern::gfx_callbacks_t::gfx_data_t
     if (ultramodern::get_graphics_config().wm_option == ultramodern::WindowMode::Fullscreen) { // TODO: Remove once RT64 gets native fullscreen support on Linux
         SDL_SetWindowFullscreen(window,SDL_WINDOW_FULLSCREEN_DESKTOP);
     } else {
-        SDL_SetWindowFullscreen(window,SDL_WINDOW_RESIZABLE);
+        SDL_SetWindowFullscreen(window,0);
     }
 #endif
 

--- a/src/ui/ui_config.cpp
+++ b/src/ui/ui_config.cpp
@@ -197,7 +197,7 @@ void apply_graphics_config(void) {
 	if (new_options.wm_option == ultramodern::WindowMode::Fullscreen) {
 		SDL_SetWindowFullscreen(window,SDL_WINDOW_FULLSCREEN_DESKTOP);
 	} else {
-		SDL_SetWindowFullscreen(window,SDL_WINDOW_RESIZABLE);
+		SDL_SetWindowFullscreen(window,0);
 	}
 #endif
 }


### PR DESCRIPTION
Adds fullscreen support to the Linux build.

Note that this is done on recomp's side, and this implementation should be removed once RT64 gets Linux fullscreen support on its side. 