### PR TITLE
Fix Linux build and locale

### DIFF
--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -293,8 +293,6 @@ int main(int argc, char** argv) {
     cfi.FontWeight = FW_NORMAL;
     wcscpy_s(cfi.FaceName, L"NSimSun");
     SetCurrentConsoleFontEx(GetStdHandle(STD_OUTPUT_HANDLE), FALSE, &cfi);
-#else
-    std::setlocale(LC_ALL, "en_US.UTF-8");
 #endif
 
     //printf("Current dir: %ls\n", std::filesystem::current_path().c_str());

--- a/src/ui/ui_renderer.cpp
+++ b/src/ui/ui_renderer.cpp
@@ -1049,6 +1049,9 @@ void recomp::get_window_size(int& width, int& height) {
 }
 
 void init_hook(RT64::RenderInterface* interface, RT64::RenderDevice* device) {
+#if defined(__linux__)
+    std::locale::global(std::locale::classic());
+#endif
     ui_context = std::make_unique<UIContext>();
 
     ui_context->rml.add_menu(recomp::Menu::Config, recomp::create_config_menu());

--- a/ultramodern/ultramodern.hpp
+++ b/ultramodern/ultramodern.hpp
@@ -21,6 +21,7 @@
 #   undef Status
 #   undef LockMask
 #   undef Always
+#   undef Success
 #endif
 
 struct UltraThreadContext {


### PR DESCRIPTION
Fixes the Linux build failing to build due to X11 banning the word Success, and also fixes the locale being wrong on non-American setups and this breaking the UI.