### PR TITLE
Apply graphics conf changes with F on kb or X/Start on cont

### DIFF
--- a/assets/config_menu/graphics.rml
+++ b/assets/config_menu/graphics.rml
@@ -311,7 +311,7 @@
                         id="apply_button"
                         style="nav-up:#hr_original"
                     >
-                        <div class="button__label">Apply</div>
+                        <div class="button__label">Apply <span class="prompt-font-sm">{{gfx_help__apply}}</span></div>
                     </button>
                 </div>
             </div>

--- a/src/ui/ui_config.cpp
+++ b/src/ui/ui_config.cpp
@@ -186,6 +186,7 @@ void recomp::set_cont_or_kb(bool cont_interacted) {
 		cont_active = cont_interacted;
 		nav_help_model_handle.DirtyVariable("nav_help__navigate");
 		nav_help_model_handle.DirtyVariable("nav_help__accept");
+		graphics_model_handle.DirtyVariable("gfx_help__apply");
 		nav_help_model_handle.DirtyVariable("nav_help__exit");
 	}
 }
@@ -439,8 +440,15 @@ public:
 		recomp::register_event(listener, "config_keydown",
 			[](const std::string& param, Rml::Event& event) {
 				if (!prompt_context.open && event.GetId() == Rml::EventId::Keydown) {
-					if (event.GetParameter<Rml::Input::KeyIdentifier>("key_identifier", Rml::Input::KeyIdentifier::KI_UNKNOWN) == Rml::Input::KeyIdentifier::KI_ESCAPE) {
-						close_config_menu();
+					auto key = event.GetParameter<Rml::Input::KeyIdentifier>("key_identifier", Rml::Input::KeyIdentifier::KI_UNKNOWN);
+					switch (key) {
+						case Rml::Input::KeyIdentifier::KI_ESCAPE:
+							close_config_menu();
+							break;
+						case Rml::Input::KeyIdentifier::KI_F:
+							graphics_model_handle.DirtyVariable("options_changed");
+							apply_graphics_config();
+							break;
 					}
 				}
 			});
@@ -596,6 +604,14 @@ public:
 				}
 				out = "";
 			});
+		
+		constructor.BindFunc("gfx_help__apply", [](Rml::Variant& out) {
+			if (cont_active) {
+				out = PF_GAMEPAD_X " " PF_GAMEPAD_START;
+			} else {
+				out = PF_KEYBOARD_F;
+			}
+		});
 
 		constructor.Bind("msaa2x_supported", &msaa2x_supported);
 		constructor.Bind("msaa4x_supported", &msaa4x_supported);

--- a/src/ui/ui_renderer.cpp
+++ b/src/ui/ui_renderer.cpp
@@ -1150,6 +1150,9 @@ int cont_button_to_key(SDL_ControllerButtonEvent& button) {
             return SDLK_RIGHT;
         case SDL_GameControllerButton::SDL_CONTROLLER_BUTTON_A:
             return SDLK_RETURN;
+        case SDL_GameControllerButton::SDL_CONTROLLER_BUTTON_X:
+        case SDL_GameControllerButton::SDL_CONTROLLER_BUTTON_START:
+            return SDLK_f;
         // Allows closing the menu
         case SDL_GameControllerButton::SDL_CONTROLLER_BUTTON_BACK:
             return SDLK_ESCAPE;


### PR DESCRIPTION
Adds the ability to apply graphics config changes by either pressing F on keyboard or X/Start on controller. Depending on which of those two was last used, the correct icon shows up inside of the `Apply` button.