### PR TITLE
Fix directional navigation between options with msaa options being disabled

### DIFF
--- a/assets/config_menu/graphics.rml
+++ b/assets/config_menu/graphics.rml
@@ -158,7 +158,8 @@
                                 data-checked="rr_option"
                                 value="Display"
                                 id="rr_display"
-                                data-attr-style="rr_option=='Manual' ? 'nav-up: #wm_fullscreen; nav-down: #rr_manual_input' : 'nav-up: #wm_fullscreen; nav-down: #msaa_2x'"
+                                style="nav-up: #wm_fullscreen"
+                                data-style-nav-down="rr_option=='Manual' ? '#rr_manual_input' : (msaa2x_supported ? '#msaa_2x' : '#msaa_none')"
                             />
                             <label class="config-option__tab-label" for="rr_display">Display</label>
                             <input type="radio"
@@ -168,7 +169,8 @@
                                 data-checked="rr_option"
                                 value="Manual"
                                 id="rr_manual"
-                                data-attr-style="rr_option=='Manual' ? 'nav-up: #wm_fullscreen; nav-down: #rr_manual_input' : 'nav-up: #wm_fullscreen; nav-down: #msaa_4x'"
+                                style="nav-up: #wm_fullscreen"
+                                data-style-nav-down="rr_option=='Manual' ? '#rr_manual_input' : (msaa4x_supported ? '#msaa_4x' : (msaa2x_supported ? '#msaa_2x' : '#msaa_none'))"
                             />
                             <label class="config-option__tab-label" for="rr_manual">Manual</label>
                         </div>
@@ -181,7 +183,7 @@
                                 type="range"
                                 min="20"
                                 max="360"
-                                style="flex:1;margin: 0dp;nav-up:auto;nav-down:auto;"
+                                style="flex:1;margin: 0dp;nav-up:#rr_manual;nav-down:#msaa_none;"
                                 data-value="rr_manual_value"
                             />
                         </div>
@@ -209,6 +211,7 @@
                                 value="MSAA2X"
                                 id="msaa_2x"
                                 data-attr-style="rr_option=='Manual' ? 'nav-up: #rr_manual_input; nav-down: #hr_16_9' : 'nav-up: #rr_display; nav-down: #hr_16_9'"
+                                data-style-nav-right="msaa4x_supported ? '#msaa_4x' : 'none'"
                             />
                             <label class="config-option__tab-label" for="msaa_2x">2x</label>
                             <input type="radio"
@@ -247,6 +250,7 @@
                                 value="Clamp16x9"
                                 id="hr_16_9"
                                 style="nav-up: #msaa_2x; nav-down: #apply_button"
+                                data-style-nav-up="msaa2x_supported ? '#msaa_2x' : '#msaa_none'"
                             />
                             <label class="config-option__tab-label" for="hr_16_9">16:9</label>
                             <input type="radio"
@@ -257,6 +261,7 @@
                                 value="Full"
                                 id="hr_full"
                                 style="nav-up: #msaa_4x; nav-down: #apply_button"
+                                data-style-nav-up="msaa4x_supported ? '#msaa_4x' : (msaa2x_supported ? '#msaa_2x' : '#msaa_none')"
                             />
                             <label class="config-option__tab-label" for="hr_full">Expand</label>
                         </div>


### PR DESCRIPTION
Before this change, on deck you couldnt navigate down from Display, or from Manual, or navigate up from 16:9 or Expand. This change makes it so that if you arrow down from Display/Manual it'll go to the closest available option - e.g. say 4x is disabled, Manual nav down goes to 2x, if 2x is disabled too, Manual nav down goes to None. Same logic applies to Display, 16:9 and Expand options. This also handles navigation when the Manual slider is open, and also handles preventing nav right on 2X when only 4X is disabled. I tested all of these conditions by hardcoding these individually to false:
```c++
	msaa2x_supported = ultramodern::RT64MaxMSAA() >= RT64::UserConfiguration::Antialiasing::MSAA2X;
	msaa4x_supported = ultramodern::RT64MaxMSAA() >= RT64::UserConfiguration::Antialiasing::MSAA4X;
```