### PR TITLE
Show quit game prompt when attempting to close window

### DIFF
--- a/include/recomp_input.h
+++ b/include/recomp_input.h
@@ -166,6 +166,8 @@ namespace recomp {
     // TODO move these
     void quicksave_save();
     void quicksave_load();
+
+    void open_quit_game_prompt();
 }
 
 #endif

--- a/src/game/input.cpp
+++ b/src/game/input.cpp
@@ -128,9 +128,19 @@ bool sdl_event_filter(void* userdata, SDL_Event* event) {
             InputState.controller_states.erase(controller_event->which);
         }
         break;
-    case SDL_EventType::SDL_QUIT:
-        ultramodern::quit();
-        return true;
+    case SDL_EventType::SDL_QUIT: {
+        if (!ultramodern::is_game_started()) {
+            ultramodern::quit();
+            return true;
+        }
+
+        if (recomp::get_current_menu() != recomp::Menu::Config) {
+            recomp::set_current_menu(recomp::Menu::Config);
+        }
+
+        recomp::open_quit_game_prompt();
+        break;
+    }
     case SDL_EventType::SDL_MOUSEWHEEL:
         {
             SDL_MouseWheelEvent* wheel_event = &event->wheel;    

--- a/src/ui/ui_config.cpp
+++ b/src/ui/ui_config.cpp
@@ -245,7 +245,7 @@ void close_config_menu() {
 	close_config_menu_impl();
 }
 
-void open_quit_game_prompt() {
+void recomp::open_quit_game_prompt() {
 	prompt_context.open_prompt(
 		"Are you sure you want to quit?",
 		"Any progress since your last save will be lost.",
@@ -458,7 +458,7 @@ public:
 
 		recomp::register_event(listener, "open_quit_game_prompt",
 			[](const std::string& param, Rml::Event& event) {
-				open_quit_game_prompt();
+				recomp::open_quit_game_prompt();
 			});
 
 		recomp::register_event(listener, "toggle_input_device",


### PR DESCRIPTION
Simple change. If the game isn't running, the game will just exit. If the game is running but the config menu isn't open, the config menu opens. And either way, the previously used exit game prompt will open!