### PR TITLE
ultramodern / recomp runtime: Relax alignment restrictions in osEPiReadIo, implement some more stubs

### DIFF
--- a/include/recomp_game.h
+++ b/include/recomp_game.h
@@ -31,6 +31,7 @@ namespace recomp {
 	bool is_rom_loaded();
 	void set_rom_contents(std::vector<uint8_t>&& new_rom);
 	void do_rom_read(uint8_t* rdram, gpr ram_address, uint32_t physical_addr, size_t num_bytes);
+	void do_rom_pio(uint8_t* rdram, gpr ram_address, uint32_t physical_addr)
 	void start(ultramodern::WindowHandle window_handle, const ultramodern::audio_callbacks_t& audio_callbacks, const ultramodern::input_callbacks_t& input_callbacks, const ultramodern::gfx_callbacks_t& gfx_callbacks);
 	void start_game(Game game);
 	void message_box(const char* message);

--- a/src/recomp/pak.cpp
+++ b/src/recomp/pak.cpp
@@ -29,3 +29,7 @@ extern "C" void osPfsFindFile_recomp(uint8_t * rdram, recomp_context * ctx) {
 extern "C" void osPfsReadWriteFile_recomp(uint8_t * rdram, recomp_context * ctx) {
 	ctx->r2 = 1; // PFS_ERR_NOPACK
 }
+
+extern "C" void osPfsChecker_recomp(uint8_t * rdram, recomp_context * ctx) {
+	ctx->r2 = 1; // PFS_ERR_NOPACK
+}

--- a/ultramodern/ultramodern.hpp
+++ b/ultramodern/ultramodern.hpp
@@ -53,7 +53,8 @@ namespace ultramodern {
 // We need a place in rdram to hold the PI handles, so pick an address in extended rdram
 constexpr uint32_t rdram_size = 1024 * 1024 * 16; // 16MB to give extra room for anything custom
 constexpr int32_t cart_handle = 0x80800000;
-constexpr int32_t flash_handle = (int32_t)(cart_handle + sizeof(OSPiHandle));
+constexpr int32_t drive_handle = (int32_t)(cart_handle + sizeof(OSPiHandle));
+constexpr int32_t flash_handle = (int32_t)(drive_handle + sizeof(OSPiHandle));
 constexpr uint32_t save_size = 1024 * 1024 / 8; // Maximum save size, 1Mbit for flash
 
 // Initialization.


### PR DESCRIPTION
 - osDriveRomInit
 - __osPiGetAccess
 - __osPiRelAccess
 - osPfsChecker

(Note that this doesn't fully implement Disk Drive DMA, it just provides initialization of the PI Handle. An attempt by a recompiled game to actually use the handle will still fail for now)