### PR TITLE
Add casts to `MEM_` macros

### DIFF
--- a/include/recomp.h
+++ b/include/recomp.h
@@ -26,33 +26,33 @@ typedef uint64_t gpr;
     ((gpr)(int32_t)((a) - (b)))
 
 #define MEM_W(offset, reg) \
-    (*(int32_t*)(rdram + ((((reg) + (offset))) - 0xFFFFFFFF80000000)))
-    //(*(int32_t*)(rdram + ((((reg) + (offset))) & 0x3FFFFFF)))
+    (*(int32_t*)(rdram + ((((gpr)(reg) + (gpr)(offset))) - 0xFFFFFFFF80000000ULL)))
+    //(*(int32_t*)(rdram + ((((gpr)(reg) + (gpr)(offset))) & 0x3FFFFFF)))
 
 #define MEM_H(offset, reg) \
-    (*(int16_t*)(rdram + ((((reg) + (offset)) ^ 2) - 0xFFFFFFFF80000000)))
-    //(*(int16_t*)(rdram + ((((reg) + (offset)) ^ 2) & 0x3FFFFFF)))
+    (*(int16_t*)(rdram + ((((gpr)(reg) + (gpr)(offset)) ^ 2) - 0xFFFFFFFF80000000ULL)))
+    //(*(int16_t*)(rdram + ((((gpr)(reg) + (gpr)(offset)) ^ 2) & 0x3FFFFFF)))
 
 #define MEM_B(offset, reg) \
-    (*(int8_t*)(rdram + ((((reg) + (offset)) ^ 3) - 0xFFFFFFFF80000000)))
-    //(*(int8_t*)(rdram + ((((reg) + (offset)) ^ 3) & 0x3FFFFFF)))
+    (*(int8_t*)(rdram + ((((gpr)(reg) + (gpr)(offset)) ^ 3) - 0xFFFFFFFF80000000ULL)))
+    //(*(int8_t*)(rdram + ((((gpr)(reg) + (gpr)(offset)) ^ 3) & 0x3FFFFFF)))
 
 #define MEM_HU(offset, reg) \
-    (*(uint16_t*)(rdram + ((((reg) + (offset)) ^ 2) - 0xFFFFFFFF80000000)))
-    //(*(uint16_t*)(rdram + ((((reg) + (offset)) ^ 2) & 0x3FFFFFF)))
+    (*(uint16_t*)(rdram + ((((gpr)(reg) + (gpr)(offset)) ^ 2) - 0xFFFFFFFF80000000ULL)))
+    //(*(uint16_t*)(rdram + ((((gpr)(reg) + (gpr)(offset)) ^ 2) & 0x3FFFFFF)))
 
 #define MEM_BU(offset, reg) \
-    (*(uint8_t*)(rdram + ((((reg) + (offset)) ^ 3) - 0xFFFFFFFF80000000)))
-    //(*(uint8_t*)(rdram + ((((reg) + (offset)) ^ 3) & 0x3FFFFFF)))
+    (*(uint8_t*)(rdram + ((((gpr)(reg) + (gpr)(offset)) ^ 3) - 0xFFFFFFFF80000000ULL)))
+    //(*(uint8_t*)(rdram + ((((gpr)(reg) + (gpr)(offset)) ^ 3) & 0x3FFFFFF)))
 
 #define SD(val, offset, reg) { \
-    *(uint32_t*)(rdram + ((((reg) + (offset) + 4)) - 0xFFFFFFFF80000000)) = (uint32_t)((gpr)(val) >> 0); \
-    *(uint32_t*)(rdram + ((((reg) + (offset) + 0)) - 0xFFFFFFFF80000000)) = (uint32_t)((gpr)(val) >> 32); \
+    *(uint32_t*)(rdram + ((((gpr)(reg) + (gpr)(offset) + 4)) - 0xFFFFFFFF80000000ULL)) = (uint32_t)((gpr)(val) >> 0); \
+    *(uint32_t*)(rdram + ((((gpr)(reg) + (gpr)(offset) + 0)) - 0xFFFFFFFF80000000ULL)) = (uint32_t)((gpr)(val) >> 32); \
 }
 
 //#define SD(val, offset, reg) { \
-//    *(uint32_t*)(rdram + ((((reg) + (offset) + 4)) & 0x3FFFFFF)) = (uint32_t)((val) >> 32); \
-//    *(uint32_t*)(rdram + ((((reg) + (offset) + 0)) & 0x3FFFFFF)) = (uint32_t)((val) >> 0); \
+//    *(uint32_t*)(rdram + ((((gpr)(reg) + (gpr)(offset) + 4)) & 0x3FFFFFF)) = (uint32_t)((val) >> 32); \
+//    *(uint32_t*)(rdram + ((((gpr)(reg) + (gpr)(offset) + 0)) & 0x3FFFFFF)) = (uint32_t)((val) >> 0); \
 //}
 
 static inline uint64_t load_doubleword(uint8_t* rdram, gpr reg, gpr offset) {

--- a/src/recomp/pi.cpp
+++ b/src/recomp/pi.cpp
@@ -143,7 +143,7 @@ void save_write_ptr(const void* in, uint32_t offset, uint32_t count) {
         std::lock_guard lock { save_context.save_buffer_mutex };
         memcpy(&save_context.save_buffer[offset], in, count);
     }
-    
+
     save_context.write_sempahore.signal();
 }
 

--- a/src/recomp/pi.cpp
+++ b/src/recomp/pi.cpp
@@ -150,7 +150,7 @@ void save_write_ptr(const void* in, uint32_t offset, uint32_t count) {
 void save_write(RDRAM_ARG PTR(void) rdram_address, uint32_t offset, uint32_t count) {
     {
         std::lock_guard lock { save_context.save_buffer_mutex };
-        for (uint32_t i = 0; i < count; i++) {
+        for (size_t i = 0; i < count; i++) {
             save_context.save_buffer[offset + i] = MEM_B(i, rdram_address);
         }
     }


### PR DESCRIPTION
Added `gpr` casts to the arguments of the `MEM_` macros to ensure the arithmetic is done as 64bits instead of something dumb because the caller passed 32bits unsigned values or similar. I also added `ULL` suffix to those big constants in the macro to ensure nothing will do something dumb.

I don't know if we want to keep the commented out versions or not. In the meantime I updated them accordingly just in case.

I also changed `save_write` to use a `size_t` instead of `uint32_t` because that's the function that gave me problems in the first place