### PR TITLE
Modernize the usage of variants

### DIFF
--- a/ultramodern/events.cpp
+++ b/ultramodern/events.cpp
@@ -343,14 +343,14 @@ void gfx_thread_func(uint8_t* rdram, moodycamel::LightweightSemaphore* thread_re
                     ultramodern::measure_input_latency();
 
                     auto rt64_start = std::chrono::high_resolution_clock::now();
-                    rt64.send_dl(&task_action->task);
+                    rt64.send_dl(&action.task);
                     auto rt64_end = std::chrono::high_resolution_clock::now();
                     dp_complete();
                 },
                 [&](const SwapBuffersAction &action)
                 {
                     events_context.vi.current_buffer = events_context.vi.next_buffer;
-                    rt64.update_screen(swap_action->origin);
+                    rt64.update_screen(action.origin);
                     display_refresh_rate = rt64.get_display_framerate();
                 },
                 [&](const UpdateConfigAction &action)
@@ -363,7 +363,7 @@ void gfx_thread_func(uint8_t* rdram, moodycamel::LightweightSemaphore* thread_re
                 },
                 [&](const LoadShaderCacheAction &action)
                 {
-                    rt64.load_shader_cache(load_shader_cache_action->data);
+                    rt64.load_shader_cache(action.data);
                 }
             );
         }

--- a/ultramodern/timer.cpp
+++ b/ultramodern/timer.cpp
@@ -3,6 +3,7 @@
 #include <set>
 #include "blockingconcurrentqueue.h"
 
+#include "utils.hpp"
 #include "ultra64.h"
 #include "ultramodern.hpp"
 
@@ -87,12 +88,16 @@ void timer_thread(RDRAM_ARG1) {
     
     // Lambda to process a timer action to handle adding and removing timers
     auto process_timer_action = [&](const Action& action) {
-        // Determine the action type and act on it
-        if (const auto* add_action = std::get_if<AddTimerAction>(&action)) {
-            active_timers.insert(add_action->timer);
-        } else if (const auto* remove_action = std::get_if<RemoveTimerAction>(&action)) {
-            active_timers.erase(remove_action->timer);
-        }
+        match(action, 
+            [&active_timers](const AddTimerAction& action)
+            {
+                active_timers.insert(action->timer);
+            },
+            [&active_timers](const RemoveTimerAction& action)
+            {
+                active_timers.erase(action->timer);
+            }
+        );
     };
 
     while (true) {

--- a/ultramodern/timer.cpp
+++ b/ultramodern/timer.cpp
@@ -91,11 +91,11 @@ void timer_thread(RDRAM_ARG1) {
         match(action, 
             [&active_timers](const AddTimerAction& action)
             {
-                active_timers.insert(action->timer);
+                active_timers.insert(action.timer);
             },
             [&active_timers](const RemoveTimerAction& action)
             {
-                active_timers.erase(action->timer);
+                active_timers.erase(action.timer);
             }
         );
     };

--- a/ultramodern/utils.hpp
+++ b/ultramodern/utils.hpp
@@ -1,0 +1,12 @@
+#include <variant>
+
+template<class... Ts> 
+struct overloaded : Ts... 
+{ 
+    using Ts::operator()...; 
+};
+
+template<class T, class... Ts>
+auto match(const T& event, Ts&&... args){
+    return std::visit(overloaded{std::forward<Ts>(args)...}, event);
+}

--- a/ultramodern/utils.hpp
+++ b/ultramodern/utils.hpp
@@ -1,3 +1,6 @@
+#ifndef __utils_HPP__
+#define __utils_HPP__
+
 #include <variant>
 
 template<class... Ts> 
@@ -10,3 +13,5 @@ template<class T, class... Ts>
 auto match(const T& event, Ts&&... args){
     return std::visit(overloaded{std::forward<Ts>(args)...}, event);
 }
+
+#endif


### PR DESCRIPTION
I cannot test this fully this changes because I don't have a decompiled game,
however, here you have an snippet from godbolt: https://godbolt.org/z/3MEfobs65
where I show the usage.

This modernizes a little bit the handling of the std::variant, from my point of view it's clearer to use std::visit and these helper functions.

the Overloaded is taken from: https://en.cppreference.com/w/cpp/utility/variant/visit and the "match" function is custom-made.

I called it match because it's similar to Rust's match. 

This is also exhaustive, it means that if some kind of new event is added, all places where you use the "variant" and "match" function will need to be updated for the new case, and if not, the compiler will give an error (which is good).