### PR TITLE
clang -> GCC disable warnings replacement

### DIFF
--- a/include/disable_warnings.h
+++ b/include/disable_warnings.h
@@ -1,4 +1,4 @@
-#ifdef __clang__
-#pragma clang diagnostic ignored "-Wunused-variable"
-#pragma clang diagnostic ignored "-Wimplicit-function-declaration"
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wunused-variable"
+#pragma GCC diagnostic ignored "-Wimplicit-function-declaration"
 #endif


### PR DESCRIPTION
Replaces clang with gcc directives in the header. Their functionality shares both compilers so it can work out for them.