### PR TITLE
Linux: Force SDL2 video driver selection to X11

### DIFF
--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -138,6 +138,10 @@ ultramodern::WindowHandle create_window(ultramodern::gfx_callbacks_t::gfx_data_t
 #elif defined(__ANDROID__)
     static_assert(false && "Unimplemented");
 #elif defined(__linux__)
+    if (wmInfo.subsystem != SDL_SYSWM_X11) {
+        exit_error("Unsupported SDL2 video driver \"%s\". Only X11 is supported on Linux.\n", SDL_GetCurrentVideoDriver());
+    }
+
     return ultramodern::WindowHandle{ wmInfo.info.x11.display, wmInfo.info.x11.window };
 #else
     static_assert(false && "Unimplemented");

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -52,7 +52,7 @@ ultramodern::gfx_callbacks_t::gfx_data_t create_gfx() {
     SDL_SetHint(SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH, "1");
     SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
 
-#if defined(__linux__) && defined(SDL_VIDEO_DRIVER_WAYLAND)
+#if defined(__linux__)
     SDL_SetHint(SDL_HINT_VIDEODRIVER, "x11");
 #endif
 

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -51,6 +51,11 @@ ultramodern::gfx_callbacks_t::gfx_data_t create_gfx() {
     SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS5_RUMBLE, "1");
     SDL_SetHint(SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH, "1");
     SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
+
+#if defined(__linux__) && defined(SDL_VIDEO_DRIVER_WAYLAND)
+    SDL_SetHint(SDL_HINT_VIDEODRIVER, "x11");
+#endif
+
     if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMECONTROLLER) > 0) {
         exit_error("Failed to initialize SDL2: %s\n", SDL_GetError());
     }


### PR DESCRIPTION
It looks like RT64 does not currently support Wayland and unconditionally expects to receive an X11 window, but on some distros (namely, Fedora in my case) SDL2 will select the Wayland video driver by default.

While it'd of course be preferable to support both, this PR adds a small change to forcibly set the SDL2 video driver to X11 if the Wayland driver is present to prevent the game from crashing for people.