### PR TITLE
Fix Skull Kid curse effect in ultrawide (32:9+)

### DIFF
--- a/patches/effect_transform_tagging.c
+++ b/patches/effect_transform_tagging.c
@@ -1,7 +1,6 @@
 #include "patches.h"
 #include "transform_ids.h"
 #include "overlays/actors/ovl_Object_Kankyo/z_object_kankyo.h"
-#include "overlays/actors/ovl_Eff_Stk/z_eff_stk.h"
 #include "overlays/actors/ovl_En_Clear_Tag/z_en_clear_tag.h"
 #include "z64effect.h"
 
@@ -391,51 +390,6 @@ void Effect_DrawAll(GraphicsContext* gfxCtx) {
         pop_effect_tag(gfxCtx);
     }
 }
-
-extern Gfx object_stk2_DL_008920[];
-extern Gfx object_stk2_DL_008A38[];
-extern AnimatedMaterial object_stk2_Matanimheader_009F60[];
-
-void EffStk_Draw(Actor* thisx, PlayState* play) {
-    EffStk* this = (EffStk*)thisx;
-    s32 pad;
-    Camera* activeCam = GET_ACTIVE_CAM(play);
-    Vec3f eye = activeCam->eye;
-    Vec3f quakeOffset;
-
-    quakeOffset = Camera_GetQuakeOffset(activeCam);
-
-    OPEN_DISPS(play->state.gfxCtx);
-
-    Gfx_SetupDL25_Xlu(play->state.gfxCtx);
-    Matrix_Translate(eye.x + quakeOffset.x, eye.y + quakeOffset.y, eye.z + quakeOffset.z, MTXMODE_NEW);
-    Matrix_Scale(0.2f, 0.2f, 0.2f, MTXMODE_APPLY);
-    Matrix_ReplaceRotation(&play->billboardMtxF);
-    Matrix_Translate(0.0f, 0.0f, this->unk148, MTXMODE_APPLY);
-
-    Mtx* mtx = Matrix_NewMtx(play->state.gfxCtx);
-
-    // @recomp Tag the transform. Do not allow edits as this will get edited by the billboard detection and we'll want to skip position during a camera cut too.
-    if (camera_was_skipped()) {
-        gEXMatrixGroupDecomposedSkipPosRot(POLY_XLU_DISP++, actor_transform_id(thisx), G_EX_PUSH, G_MTX_MODELVIEW, G_EX_EDIT_NONE);
-    }
-    else {
-        gEXMatrixGroupDecomposedNormal(POLY_XLU_DISP++, actor_transform_id(thisx), G_EX_PUSH, G_MTX_MODELVIEW, G_EX_EDIT_NONE);
-    }
-
-    gSPMatrix(POLY_XLU_DISP++, mtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
-    AnimatedMat_DrawAlphaStep(play, Lib_SegmentedToVirtual(object_stk2_Matanimheader_009F60), 1.0f, this->unk144);
-    gDPSetColorDither(POLY_XLU_DISP++, G_CD_NOISE);
-    gDPSetAlphaDither(POLY_XLU_DISP++, G_AD_NOISE);
-    gSPDisplayList(POLY_XLU_DISP++, object_stk2_DL_008920);
-    gSPDisplayList(POLY_XLU_DISP++, object_stk2_DL_008A38);
-
-    // @recomp Pop the transform tag.
-    gEXPopMatrixGroup(POLY_XLU_DISP++, G_MTX_MODELVIEW);
-
-    CLOSE_DISPS(play->state.gfxCtx);
-}
-
 
 typedef enum {
     /* 0x00 */ CLEAR_TAG_EFFECT_AVAILABLE,

--- a/patches/ocarina_effect_patches.c
+++ b/patches/ocarina_effect_patches.c
@@ -6,6 +6,8 @@
 #include "overlays/actors/ovl_Oceff_Wipe5/z_oceff_wipe5.h"
 #include "overlays/actors/ovl_Oceff_Wipe6/z_oceff_wipe6.h"
 #include "overlays/actors/ovl_Oceff_Wipe7/z_oceff_wipe7.h"
+#include "overlays/actors/ovl_Eff_Stk/z_eff_stk.h"
+#include "transform_ids.h"
 
 // @recomp Custom verts to extend the effects past the camera so they cover any aspect ratio.
 Vtx time_override_verts[156] = {
@@ -779,6 +781,204 @@ Gfx healing_override_dl[] = {
 	gsSPEndDisplayList(),
 };
 
+Vtx skull_kid_curse_1_override_verts[52] = { // 008A38
+    {{ {71, 23, 0}, 0, {614, 1024}, {255, 255, 255, 0} }},
+    {{ {121, 88, 500}, 0, {716, 0}, {255, 255, 255, 255} }},
+    {{ {44, 61, 0}, 0, {819, 1024}, {255, 255, 255, 0} }},
+    {{ {46, 143, 500}, 0, {921, 0}, {255, 255, 255, 255} }},
+    {{ {0, 75, 0}, 0, {1024, 1024}, {255, 255, 255, 0} }},
+    {{ {-46, 143, 500}, 0, {1126, 0}, {255, 255, 255, 255} }},
+    {{ {-44, 61, 0}, 0, {1228, 1024}, {255, 255, 255, 0} }},
+    {{ {-121, 88, 500}, 0, {1331, 0}, {255, 255, 255, 255} }},
+    {{ {-71, 23, 0}, 0, {1433, 1024}, {255, 255, 255, 0} }},
+    {{ {-150, 0, 500}, 0, {1536, 0}, {255, 255, 255, 255} }},
+    {{ {-71, -23, 0}, 0, {1638, 1024}, {255, 255, 255, 0} }},
+    {{ {-121, -88, 500}, 0, {1740, 0}, {255, 255, 255, 255} }},
+    {{ {-44, -61, 0}, 0, {1843, 1024}, {255, 255, 255, 0} }},
+    {{ {-46, -143, 500}, 0, {1945, 0}, {255, 255, 255, 255} }},
+    {{ {0, -75, 0}, 0, {2048, 1024}, {255, 255, 255, 0} }},
+    {{ {0, -75, 0}, 0, {0, 1024}, {255, 255, 255, 0} }},
+    {{ {46, -143, 500}, 0, {102, 0}, {255, 255, 255, 255} }},
+    {{ {44, -61, 0}, 0, {204, 1024}, {255, 255, 255, 0} }},
+    {{ {121, -88, 500}, 0, {307, 0}, {255, 255, 255, 255} }},
+    {{ {71, -23, 0}, 0, {409, 1024}, {255, 255, 255, 0} }},
+    {{ {150, 0, 500}, 0, {512, 0}, {255, 255, 255, 255} }},
+    {{ {248, 0, 1080}, 0, {580, -1192}, {255, 255, 255, 255} }},
+    {{ {200, 146, 1080}, 0, {782, -1192}, {255, 255, 255, 255} }},
+    {{ {200, 146, 1080}, 0, {782, -1192}, {255, 255, 255, 255} }},
+    {{ {76, 237, 1080}, 0, {989, -1192}, {255, 255, 255, 255} }},
+    {{ {76, 237, 1080}, 0, {988, -1192}, {255, 255, 255, 255} }},
+    {{ {-76, 237, 1080}, 0, {1193, -1192}, {255, 255, 255, 255} }},
+    {{ {-76, 237, 1080}, 0, {1194, -1192}, {255, 255, 255, 255} }},
+    {{ {-200, 146, 1080}, 0, {1397, -1192}, {255, 255, 255, 255} }},
+    {{ {-200, 146, 1080}, 0, {1397, -1192}, {255, 255, 255, 255} }},
+    {{ {-248, 0, 1080}, 0, {1604, -1192}, {255, 255, 255, 255} }},
+    {{ {-248, 0, 1080}, 0, {1604, -1192}, {255, 255, 255, 255} }},
+    {{ {-121, -88, 500}, 0, {1740, 0}, {255, 255, 255, 255} }},
+    {{ {-248, 0, 1080}, 0, {1604, -1192}, {255, 255, 255, 255} }},
+    {{ {-200, -146, 1080}, 0, {1806, -1192}, {255, 255, 255, 255} }},
+    {{ {-44, -61, 0}, 0, {1843, 1024}, {255, 255, 255, 0} }},
+    {{ {-46, -143, 500}, 0, {1945, 0}, {255, 255, 255, 255} }},
+    {{ {-200, -146, 1080}, 0, {1806, -1192}, {255, 255, 255, 255} }},
+    {{ {-76, -237, 1080}, 0, {2013, -1192}, {255, 255, 255, 255} }},
+    {{ {0, -75, 0}, 0, {2048, 1024}, {255, 255, 255, 0} }},
+    {{ {46, -143, 500}, 0, {2150, 0}, {255, 255, 255, 255} }},
+    {{ {-76, -237, 1080}, 0, {2012, -1192}, {255, 255, 255, 255} }},
+    {{ {76, -237, 1080}, 0, {2217, -1192}, {255, 255, 255, 255} }},
+    {{ {44, -61, 0}, 0, {204, 1024}, {255, 255, 255, 0} }},
+    {{ {46, -143, 500}, 0, {102, 0}, {255, 255, 255, 255} }},
+    {{ {121, -88, 500}, 0, {307, 0}, {255, 255, 255, 255} }},
+    {{ {76, -237, 1080}, 0, {170, -1192}, {255, 255, 255, 255} }},
+    {{ {200, -146, 1080}, 0, {373, -1192}, {255, 255, 255, 255} }},
+    {{ {71, -23, 0}, 0, {409, 1024}, {255, 255, 255, 0} }},
+    {{ {150, 0, 500}, 0, {512, 0}, {255, 255, 255, 255} }},
+    {{ {200, -146, 1080}, 0, {373, -1192}, {255, 255, 255, 255} }},
+    {{ {248, 0, 1080}, 0, {580, -1192}, {255, 255, 255, 255} }},
+};
+
+extern u64 object_stk2_Tex_008B50[];
+extern u64 object_stk2_Tex_008B50[];
+
+
+Gfx skull_kid_curse_1_override_dl[] = { // 008A38
+    gsSPTexture(0xFFFF, 0xFFFF, 0, G_TX_RENDERTILE, G_ON),
+    gsDPPipeSync(),
+    gsDPSetCombineLERP(TEXEL1, PRIMITIVE, PRIM_LOD_FRAC, TEXEL0, TEXEL1, 0, PRIM_LOD_FRAC, TEXEL0, PRIMITIVE,
+                       ENVIRONMENT, COMBINED, ENVIRONMENT, COMBINED, 0, SHADE, 0),
+    gsDPSetPrimColor(0, 0x80, 255, 255, 100, 255),
+    gsDPSetEnvColor(255, 0, 150, 255),
+    gsDPSetRenderMode(G_RM_PASS, G_RM_ZB_XLU_SURF2),
+    gsDPSetTextureLUT(G_TT_NONE),
+    gsDPLoadTextureBlock(object_stk2_Tex_008B50, G_IM_FMT_I, G_IM_SIZ_8b, 32, 64, 0, G_TX_NOMIRROR | G_TX_WRAP,
+                         G_TX_NOMIRROR | G_TX_WRAP, 5, 6, 1, 15),
+    gsDPLoadMultiBlock(object_stk2_Tex_008B50, 0x0000, 1, G_IM_FMT_I, G_IM_SIZ_8b, 32, 64, 0, G_TX_NOMIRROR | G_TX_WRAP,
+                       G_TX_NOMIRROR | G_TX_WRAP, 5, 6, 15, 14),
+    gsSPDisplayList(0x08000000),
+    gsSPLoadGeometryMode(G_ZBUFFER | G_SHADE | G_CULL_BACK | G_SHADING_SMOOTH),
+    gsSPVertex(skull_kid_curse_1_override_verts + 0, 32, 0),
+    gsSP2Triangles(0, 1, 2, 0, 2, 3, 4, 0),
+    gsSP2Triangles(4, 5, 6, 0, 6, 7, 8, 0),
+    gsSP2Triangles(8, 9, 10, 0, 10, 11, 12, 0),
+    gsSP2Triangles(12, 13, 14, 0, 15, 16, 17, 0),
+    gsSP2Triangles(17, 18, 19, 0, 19, 20, 0, 0),
+    gsSP2Triangles(0, 20, 1, 0, 1, 20, 21, 0),
+    gsSP2Triangles(1, 21, 22, 0, 2, 1, 3, 0),
+    gsSP2Triangles(3, 1, 23, 0, 3, 23, 24, 0),
+    gsSP2Triangles(4, 3, 5, 0, 5, 3, 25, 0),
+    gsSP2Triangles(5, 25, 26, 0, 6, 5, 7, 0),
+    gsSP2Triangles(7, 5, 27, 0, 7, 27, 28, 0),
+    gsSP2Triangles(8, 7, 9, 0, 9, 7, 29, 0),
+    gsSP2Triangles(9, 29, 30, 0, 10, 9, 11, 0),
+    gsSP1Triangle(11, 9, 31, 0),
+    gsSPVertex(skull_kid_curse_1_override_verts + 32, 20, 0),
+    gsSP2Triangles(0, 1, 2, 0, 3, 0, 4, 0),
+    gsSP2Triangles(4, 0, 5, 0, 4, 5, 6, 0),
+    gsSP2Triangles(7, 4, 8, 0, 8, 4, 9, 0),
+    gsSP2Triangles(8, 9, 10, 0, 11, 12, 13, 0),
+    gsSP2Triangles(13, 12, 14, 0, 13, 14, 15, 0),
+    gsSP2Triangles(16, 13, 17, 0, 17, 13, 18, 0),
+    gsSP1Triangle(17, 18, 19, 0),
+    gsSPEndDisplayList(),
+};
+
+Vtx skull_kid_curse_2_override_verts[52] = { // 008920
+    {{ {86, -28, 0}, 0, {409, 1024}, {255, 255, 255, 0} }},
+    {{ {180, 0, 500}, 0, {512, 0}, {255, 255, 255, 255} }},
+    {{ {86, 28, 0}, 0, {614, 1024}, {255, 255, 255, 0} }},
+    {{ {53, -73, 0}, 0, {204, 1024}, {255, 255, 255, 0} }},
+    {{ {146, -106, 500}, 0, {307, 0}, {255, 255, 255, 255} }},
+    {{ {0, -90, 0}, 0, {0, 1024}, {255, 255, 255, 0} }},
+    {{ {56, -171, 500}, 0, {102, 0}, {255, 255, 255, 255} }},
+    {{ {-53, -73, 0}, 0, {1843, 1024}, {255, 255, 255, 0} }},
+    {{ {-56, -171, 500}, 0, {1945, 0}, {255, 255, 255, 255} }},
+    {{ {0, -90, 0}, 0, {2048, 1024}, {255, 255, 255, 0} }},
+    {{ {-86, -28, 0}, 0, {1638, 1024}, {255, 255, 255, 0} }},
+    {{ {-146, -106, 500}, 0, {1740, 0}, {255, 255, 255, 255} }},
+    {{ {-86, 28, 0}, 0, {1433, 1024}, {255, 255, 255, 0} }},
+    {{ {-180, 0, 500}, 0, {1536, 0}, {255, 255, 255, 255} }},
+    {{ {-53, 73, 0}, 0, {1228, 1024}, {255, 255, 255, 0} }},
+    {{ {-146, 106, 500}, 0, {1331, 0}, {255, 255, 255, 255} }},
+    {{ {0, 90, 0}, 0, {1024, 1024}, {255, 255, 255, 0} }},
+    {{ {-56, 171, 500}, 0, {1126, 0}, {255, 255, 255, 255} }},
+    {{ {53, 73, 0}, 0, {819, 1024}, {255, 255, 255, 0} }},
+    {{ {56, 171, 500}, 0, {921, 0}, {255, 255, 255, 255} }},
+    {{ {146, 106, 500}, 0, {716, 0}, {255, 255, 255, 255} }},
+    {{ {218, -159, 1080}, 0, {359, -1185}, {255, 255, 255, 255} }},
+    {{ {269, 0, 1080}, 0, {562, -1185}, {255, 255, 255, 255} }},
+    {{ {84, -256, 1080}, 0, {152, -1185}, {255, 255, 255, 255} }},
+    {{ {218, -159, 1080}, 0, {359, -1185}, {255, 255, 255, 255} }},
+    {{ {56, -171, 500}, 0, {2150, 0}, {255, 255, 255, 255} }},
+    {{ {-84, -256, 1080}, 0, {1996, -1185}, {255, 255, 255, 255} }},
+    {{ {84, -256, 1080}, 0, {2201, -1185}, {255, 255, 255, 255} }},
+    {{ {-218, -159, 1080}, 0, {1792, -1185}, {255, 255, 255, 255} }},
+    {{ {-84, -256, 1080}, 0, {1995, -1185}, {255, 255, 255, 255} }},
+    {{ {-269, 0, 1080}, 0, {1586, -1185}, {255, 255, 255, 255} }},
+    {{ {-218, -159, 1080}, 0, {1791, -1185}, {255, 255, 255, 255} }},
+    {{ {-180, 0, 500}, 0, {1536, 0}, {255, 255, 255, 255} }},
+    {{ {-146, 106, 500}, 0, {1331, 0}, {255, 255, 255, 255} }},
+    {{ {-218, 159, 1080}, 0, {1383, -1185}, {255, 255, 255, 255} }},
+    {{ {-269, 0, 1080}, 0, {1586, -1185}, {255, 255, 255, 255} }},
+    {{ {-53, 73, 0}, 0, {1228, 1024}, {255, 255, 255, 0} }},
+    {{ {-56, 171, 500}, 0, {1126, 0}, {255, 255, 255, 255} }},
+    {{ {-84, 256, 1080}, 0, {1176, -1185}, {255, 255, 255, 255} }},
+    {{ {-218, 159, 1080}, 0, {1383, -1185}, {255, 255, 255, 255} }},
+    {{ {0, 90, 0}, 0, {1024, 1024}, {255, 255, 255, 0} }},
+    {{ {56, 171, 500}, 0, {921, 0}, {255, 255, 255, 255} }},
+    {{ {84, 256, 1080}, 0, {972, -1185}, {255, 255, 255, 255} }},
+    {{ {-84, 256, 1080}, 0, {1177, -1185}, {255, 255, 255, 255} }},
+    {{ {53, 73, 0}, 0, {819, 1024}, {255, 255, 255, 0} }},
+    {{ {146, 106, 500}, 0, {716, 0}, {255, 255, 255, 255} }},
+    {{ {218, 159, 1080}, 0, {768, -1185}, {255, 255, 255, 255} }},
+    {{ {84, 256, 1080}, 0, {971, -1185}, {255, 255, 255, 255} }},
+    {{ {86, 28, 0}, 0, {614, 1024}, {255, 255, 255, 0} }},
+    {{ {180, 0, 500}, 0, {512, 0}, {255, 255, 255, 255} }},
+    {{ {269, 0, 1080}, 0, {562, -1185}, {255, 255, 255, 255} }},
+    {{ {218, 159, 1080}, 0, {767, -1185}, {255, 255, 255, 255} }},
+};
+
+extern u64 object_stk2_Tex_009750[];
+extern u64 object_stk2_Tex_009350[];
+
+Gfx skull_kid_curse_2_override_dl[] = { // 008920
+    gsSPTexture(0xFFFF, 0xFFFF, 0, G_TX_RENDERTILE, G_ON),
+    gsDPPipeSync(),
+    gsDPSetCombineLERP(TEXEL1, PRIMITIVE, PRIM_LOD_FRAC, TEXEL0, TEXEL1, 0, PRIM_LOD_FRAC, TEXEL0, PRIMITIVE,
+                        ENVIRONMENT, COMBINED, ENVIRONMENT, COMBINED, 0, SHADE, 0),
+    gsDPSetPrimColor(0, 0x80, 0, 0, 255, 255),
+    gsDPSetEnvColor(0, 220, 0, 255),
+    gsDPSetRenderMode(G_RM_PASS, G_RM_AA_ZB_XLU_INTER2),
+    gsDPSetTextureLUT(G_TT_NONE),
+    gsDPLoadTextureBlock(object_stk2_Tex_009750, G_IM_FMT_I, G_IM_SIZ_8b, 32, 64, 0, G_TX_NOMIRROR | G_TX_WRAP,
+                            G_TX_MIRROR | G_TX_WRAP, 5, 6, 15, 14),
+    gsDPLoadMultiBlock(object_stk2_Tex_009350, 0x0100, 1, G_IM_FMT_I, G_IM_SIZ_8b, 32, 32, 0, G_TX_NOMIRROR | G_TX_WRAP,
+                        G_TX_NOMIRROR | G_TX_WRAP, 5, 5, 15, 1),
+    gsSPDisplayList(0x09000000),
+    gsSPLoadGeometryMode(G_ZBUFFER | G_SHADE | G_CULL_BACK | G_SHADING_SMOOTH),
+    gsSPVertex(skull_kid_curse_2_override_verts + 0, 32, 0),
+    gsSP2Triangles(0, 1, 2, 0, 3, 4, 0, 0),
+    gsSP2Triangles(5, 6, 3, 0, 7, 8, 9, 0),
+    gsSP2Triangles(10, 11, 7, 0, 12, 13, 10, 0),
+    gsSP2Triangles(14, 15, 12, 0, 16, 17, 14, 0),
+    gsSP2Triangles(18, 19, 16, 0, 2, 20, 18, 0),
+    gsSP2Triangles(0, 4, 1, 0, 1, 4, 21, 0),
+    gsSP2Triangles(1, 21, 22, 0, 3, 6, 4, 0),
+    gsSP2Triangles(4, 6, 23, 0, 4, 23, 24, 0),
+    gsSP2Triangles(9, 8, 25, 0, 25, 8, 26, 0),
+    gsSP2Triangles(25, 26, 27, 0, 7, 11, 8, 0),
+    gsSP2Triangles(8, 11, 28, 0, 8, 28, 29, 0),
+    gsSP2Triangles(10, 13, 11, 0, 11, 13, 30, 0),
+    gsSP2Triangles(11, 30, 31, 0, 12, 15, 13, 0),
+    gsSPVertex(skull_kid_curse_2_override_verts + 32, 20, 0),
+    gsSP2Triangles(0, 1, 2, 0, 0, 2, 3, 0),
+    gsSP2Triangles(4, 5, 1, 0, 1, 5, 6, 0),
+    gsSP2Triangles(1, 6, 7, 0, 8, 9, 5, 0),
+    gsSP2Triangles(5, 9, 10, 0, 5, 10, 11, 0),
+    gsSP2Triangles(12, 13, 9, 0, 9, 13, 14, 0),
+    gsSP2Triangles(9, 14, 15, 0, 16, 17, 13, 0),
+    gsSP2Triangles(13, 17, 18, 0, 13, 18, 19, 0),
+    gsSPEndDisplayList(),
+};
+
 // Sets the flag to 1 for any vertex that has an alpha of 255.
 void set_vertex_flags(Vtx* verts, s32 count) {
     for (s32 i = 0; i < count; i++) {
@@ -1246,6 +1446,51 @@ void OceffWipe7_Draw(Actor* thisx, PlayState* play) {
     // @recomp Manual relocations, TODO remove when automated.
     AnimatedMat_Draw(play, (AnimatedMaterial*)actor_relocate(thisx, sSongofHealingEffectTexAnim));
     gSPDisplayList(POLY_XLU_DISP++, (Gfx*)actor_relocate(thisx, &sSongOfHealingEffectFrustumDL));
+
+    CLOSE_DISPS(play->state.gfxCtx);
+}
+
+extern AnimatedMaterial object_stk2_Matanimheader_009F60[];
+
+// @recomp Patch the Skull Kid curse effect as well, which works similarly to the ocarina effects.
+// In this case, the patch also includes effect transform tagging patches.
+void EffStk_Draw(Actor* thisx, PlayState* play) {
+    EffStk* this = (EffStk*)thisx;
+    s32 pad;
+    Camera* activeCam = GET_ACTIVE_CAM(play);
+    Vec3f eye = activeCam->eye;
+    Vec3f quakeOffset;
+
+    quakeOffset = Camera_GetQuakeOffset(activeCam);
+
+    OPEN_DISPS(play->state.gfxCtx);
+
+    Gfx_SetupDL25_Xlu(play->state.gfxCtx);
+    Matrix_Translate(eye.x + quakeOffset.x, eye.y + quakeOffset.y, eye.z + quakeOffset.z, MTXMODE_NEW);
+    Matrix_Scale(0.2f, 0.2f, 0.2f, MTXMODE_APPLY);
+    Matrix_ReplaceRotation(&play->billboardMtxF);
+    Matrix_Translate(0.0f, 0.0f, this->unk148, MTXMODE_APPLY);
+
+    Mtx* mtx = Matrix_NewMtx(play->state.gfxCtx);
+
+    // @recomp Tag the transform. Do not allow edits as this will get edited by the billboard detection and we'll want to skip position during a camera cut too.
+    if (camera_was_skipped()) {
+        gEXMatrixGroupDecomposedSkipPosRot(POLY_XLU_DISP++, actor_transform_id(thisx), G_EX_PUSH, G_MTX_MODELVIEW, G_EX_EDIT_NONE);
+    }
+    else {
+        gEXMatrixGroupDecomposedNormal(POLY_XLU_DISP++, actor_transform_id(thisx), G_EX_PUSH, G_MTX_MODELVIEW, G_EX_EDIT_NONE);
+    }
+
+    gSPMatrix(POLY_XLU_DISP++, mtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+    AnimatedMat_DrawAlphaStep(play, Lib_SegmentedToVirtual(object_stk2_Matanimheader_009F60), 1.0f, this->unk144);
+    gDPSetColorDither(POLY_XLU_DISP++, G_CD_NOISE);
+    gDPSetAlphaDither(POLY_XLU_DISP++, G_AD_NOISE);
+    // @recomp Use the new DLs instead of the originals.
+    gSPDisplayList(POLY_XLU_DISP++, skull_kid_curse_2_override_dl);
+    gSPDisplayList(POLY_XLU_DISP++, skull_kid_curse_1_override_dl);
+
+    // @recomp Pop the transform tag.
+    gEXPopMatrixGroup(POLY_XLU_DISP++, G_MTX_MODELVIEW);
 
     CLOSE_DISPS(play->state.gfxCtx);
 }


### PR DESCRIPTION
The Skull Kid curse effect seemed to be fine in widescreen / ultrawide, but it turns out at extremely wide aspect ratios like 32:9 it does get cut off. Therefore, I've replaced the meshes (it uses 2 DLs!) in a similar way to what I did with the ocarina effects.

The particular function used to render this effect (`EffStk_Draw`) already had patches applied to it in `effect_transform_tagging.c`. So I just added my patches to the existing patched function. However, this patch involves adding 2 arrays of vertices and a 2 new DLs, so in order to avoid clutter in that file, I moved the function over to `ocarina_effect_patches.c` with the other patches for the widescreen ocarina effects. This means it's the only function in this file to be patched for more stuff than just widescreen (I think), but I think that's better than cluttering `effect_transform_tagging.c` up.

Anyways. Here's the effect in all its W I D E glory:

https://github.com/Zelda64Recomp/Zelda64Recomp/assets/15913880/283273ea-da09-4597-96e4-a4e056058001
