### PR TITLE
Automatic save backup system

### DIFF
--- a/src/ui/ui_renderer.cpp
+++ b/src/ui/ui_renderer.cpp
@@ -1477,4 +1477,5 @@ recomp::Menu recomp::get_current_menu() {
 
 void recomp::message_box(const char* msg) {
     SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, recomp::program_name.data(), msg, nullptr);
+    printf("[ERROR] %s\n", msg);
 }


### PR DESCRIPTION
When saving the game, it will be saved to a temp file, then the current save will be renamed to be a backup, and the temp file is then renamed to be the actual file. This prevents save corruption.

Making it a draft PR so you can also add the error message when the save can't be written before merging.