### PR TITLE
Add main volume option to settings

### DIFF
--- a/assets/config_menu/sound.rml
+++ b/assets/config_menu/sound.rml
@@ -7,12 +7,29 @@
                 <!-- Options -->
                 <div class="config__wrapper" data-event-mouseout="set_cur_config_index(-1)">
                         <div class="config-option" data-event-mouseover="set_cur_config_index(0)">
+                            <label class="config-option__title">Main Volume</label>
+                            <div class="config-option__range-wrapper config-option__list">
+                                <label class="config-option__range-label">{{main_volume}}%</label>
+                                <input
+                                    data-event-blur="set_cur_config_index(-1)"
+                                    data-event-focus="set_cur_config_index(0)"
+                                    class="nav-vert"
+                                    id="main_volume_input"
+                                    type="range"
+                                    min="0"
+                                    max="100"
+                                    style="flex: 1; margin: 0dp; nav-up: #tab_sound; nav-down: #lhb_on;"
+                                    data-value="main_volume"
+                                />
+                            </div>
+                        </div>
+                        <div class="config-option" data-event-mouseover="set_cur_config_index(1)">
                             <label class="config-option__title">Background Music Volume</label>
                             <div class="config-option__range-wrapper config-option__list">
                                 <label class="config-option__range-label">{{bgm_volume}}%</label>
                                 <input
                                     data-event-blur="set_cur_config_index(-1)"
-                                    data-event-focus="set_cur_config_index(0)"
+                                    data-event-focus="set_cur_config_index(1)"
                                     class="nav-vert"
                                     id="bgm_volume_input"
                                     type="range"
@@ -24,13 +41,13 @@
                             </div>
                         </div>
 
-                        <div class="config-option" data-event-mouseover="set_cur_config_index(1)">
+                        <div class="config-option" data-event-mouseover="set_cur_config_index(2)">
                             <label class="config-option__title">Low Health Beeps</label>
                             <div class="config-option__list">
                                 <input
                                     type="radio"
                                     data-event-blur="set_cur_config_index(-1)"
-                                    data-event-focus="set_cur_config_index(1)"
+                                    data-event-focus="set_cur_config_index(2)"
                                     name="lhb"
                                     data-checked="low_health_beeps_enabled"
                                     value="1"
@@ -42,7 +59,7 @@
                                 <input
                                     type="radio"
                                     data-event-blur="set_cur_config_index(-1)"
-                                    data-event-focus="set_cur_config_index(1)"
+                                    data-event-focus="set_cur_config_index(2)"
                                     name="lhb"
                                     data-checked="low_health_beeps_enabled"
                                     value="0"
@@ -55,10 +72,13 @@
                 </div>
                 <!-- Descriptions -->
                 <div class="config__wrapper">
-                    <p data-if="cur_config_index == 0">
+					<p data-if="cur_config_index == 0">
+						Controls the main volume of the game.
+					</p>
+                    <p data-if="cur_config_index == 1">
                         Controls the overall volume of background music.
                     </p>
-                    <p data-if="cur_config_index == 1">
+                    <p data-if="cur_config_index == 2">
                         Toggles whether or not the low-health beeping sound plays.
                     </p>
                 </div>

--- a/assets/config_menu/sound.rml
+++ b/assets/config_menu/sound.rml
@@ -18,7 +18,7 @@
                                     type="range"
                                     min="0"
                                     max="100"
-                                    style="flex: 1; margin: 0dp; nav-up: #tab_sound; nav-down: #lhb_on;"
+                                    style="flex: 1; margin: 0dp; nav-up: #tab_sound; nav-down: #bgm_volume_input;"
                                     data-value="main_volume"
                                 />
                             </div>
@@ -35,7 +35,7 @@
                                     type="range"
                                     min="0"
                                     max="100"
-                                    style="flex: 1; margin: 0dp; nav-up: #tab_sound; nav-down: #lhb_on;"
+                                    style="flex: 1; margin: 0dp; nav-up: #main_volume_input; nav-down: #lhb_on;"
                                     data-value="bgm_volume"
                                 />
                             </div>

--- a/include/recomp_sound.h
+++ b/include/recomp_sound.h
@@ -3,6 +3,8 @@
 
 namespace recomp {
     void reset_sound_settings();
+    void set_main_volume(int volume);
+    int get_main_volume();
     void set_bgm_volume(int volume);
     int get_bgm_volume();
     void set_low_health_beeps_enabled(bool enabled);

--- a/patches/sound.h
+++ b/patches/sound.h
@@ -3,7 +3,6 @@
 
 #include "patch_helpers.h"
 
-DECLARE_FUNC(float, recomp_get_main_volume);
 DECLARE_FUNC(float, recomp_get_bgm_volume);
 DECLARE_FUNC(u32, recomp_get_low_health_beeps_enabled);
 

--- a/patches/sound.h
+++ b/patches/sound.h
@@ -3,6 +3,7 @@
 
 #include "patch_helpers.h"
 
+DECLARE_FUNC(float, recomp_get_main_volume);
 DECLARE_FUNC(float, recomp_get_bgm_volume);
 DECLARE_FUNC(u32, recomp_get_low_health_beeps_enabled);
 

--- a/src/game/config.cpp
+++ b/src/game/config.cpp
@@ -344,6 +344,7 @@ void load_controls_config(const std::filesystem::path& path) {
 void save_sound_config(const std::filesystem::path& path) {
     nlohmann::json config_json{};
 
+    config_json["main_volume"] = recomp::get_main_volume();
     config_json["bgm_volume"] = recomp::get_bgm_volume();
     config_json["low_health_beeps"] = recomp::get_low_health_beeps_enabled();
     
@@ -357,8 +358,8 @@ void load_sound_config(const std::filesystem::path& path) {
 
     config_file >> config_json;
 
-    
     recomp::reset_sound_settings();
+    call_if_key_exists(recomp::set_main_volume, config_json, "main_volume");
     call_if_key_exists(recomp::set_bgm_volume, config_json, "bgm_volume");
     call_if_key_exists(recomp::set_low_health_beeps_enabled, config_json, "low_health_beeps");
 }

--- a/src/game/recomp_api.cpp
+++ b/src/game/recomp_api.cpp
@@ -78,6 +78,9 @@ extern "C" void recomp_get_targeting_mode(uint8_t* rdram, recomp_context* ctx) {
     _return(ctx, static_cast<int>(recomp::get_targeting_mode()));
 }
 
+extern "C" void recomp_get_main_volume(uint8_t* rdram, recomp_context* ctx) {
+	_return(ctx, recomp::get_main_volume() / 100.0f);
+}
 
 extern "C" void recomp_get_bgm_volume(uint8_t* rdram, recomp_context* ctx) {
     _return(ctx, recomp::get_bgm_volume() / 100.0f);

--- a/src/game/recomp_api.cpp
+++ b/src/game/recomp_api.cpp
@@ -78,10 +78,6 @@ extern "C" void recomp_get_targeting_mode(uint8_t* rdram, recomp_context* ctx) {
     _return(ctx, static_cast<int>(recomp::get_targeting_mode()));
 }
 
-extern "C" void recomp_get_main_volume(uint8_t* rdram, recomp_context* ctx) {
-	_return(ctx, recomp::get_main_volume() / 100.0f);
-}
-
 extern "C" void recomp_get_bgm_volume(uint8_t* rdram, recomp_context* ctx) {
     _return(ctx, recomp::get_bgm_volume() / 100.0f);
 }

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -23,6 +23,7 @@
 #include "recomp_input.h"
 #include "recomp_config.h"
 #include "recomp_game.h"
+#include "recomp_sound.h"
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
@@ -191,9 +192,10 @@ void queue_samples(int16_t* audio_data, size_t sample_count) {
 
     // Convert the audio from 16-bit values to floats and swap the audio channels into the
     // swap buffer to correct for the address xor caused by endianness handling.
+    float cur_main_volume = recomp::get_main_volume() / 100.0f; // Get the current main volume, normalized to 0.0-1.0.
     for (size_t i = 0; i < sample_count; i += input_channels) {
-        swap_buffer[i + 0 + duplicated_input_frames * input_channels] = audio_data[i + 1] * (0.5f / 32768.0f);
-        swap_buffer[i + 1 + duplicated_input_frames * input_channels] = audio_data[i + 0] * (0.5f / 32768.0f);
+        swap_buffer[i + 0 + duplicated_input_frames * input_channels] = audio_data[i + 1] * (0.5f / 32768.0f) * cur_main_volume;
+        swap_buffer[i + 1 + duplicated_input_frames * input_channels] = audio_data[i + 0] * (0.5f / 32768.0f) * cur_main_volume;
     }
     
     // TODO handle cases where a chunk is smaller than the duplicated frame count.


### PR DESCRIPTION
This commit adds the option to control the main volume game via a slider added to the "Sound" tab in the settings menu.

Aims to address https://github.com/Zelda64Recomp/Zelda64Recomp/issues/207