### PR TITLE
Fixes #279: Adjusted autocam/analog cam behavior while inside of a deku flower and when goron rolling spikes start

### DIFF
--- a/patches/camera_patches.c
+++ b/patches/camera_patches.c
@@ -1884,6 +1884,10 @@ bool get_analog_cam_active() {
     return analog_cam_active;
 }
 
+void set_analog_cam_active(bool isActive) {
+    analog_cam_active = isActive;
+}
+
 // Calling this will avoid analog cam taking over for the following game loop.
 // E.g. using left stick inputs while in a deku flower taking priority over right stick.
 void skip_analog_cam_once() {

--- a/patches/camera_patches.c
+++ b/patches/camera_patches.c
@@ -67,7 +67,7 @@ void update_analog_cam(Camera* c) {
         analog_cam_active = false;
         analog_cam_skip_once = false;
     }
-
+    
     // Record the Z targeting state.
     prev_targeting_held = targeting_held;
 
@@ -1884,8 +1884,11 @@ bool get_analog_cam_active() {
     return analog_cam_active;
 }
 
-void set_analog_cam_active(bool is_active) {
-    analog_cam_active = is_active;
+// Calling this will avoid analog cam taking over for the following game loop.
+// E.g. using left stick inputs while in a deku flower taking priority over right stick.
+void skip_analog_cam_once() {
+    analog_cam_skip_once = true;
+    analog_cam_active = false;
 }
 
 // Calling this will avoid analog cam taking over for the following game loop.

--- a/patches/camera_patches.c
+++ b/patches/camera_patches.c
@@ -8,6 +8,7 @@
 static bool prev_analog_cam_active = false;
 static bool can_use_analog_cam = false;
 static bool analog_cam_active = false;
+static bool analog_cam_skip_once = false;
 
 VecGeo analog_camera_pos = { .r = 66.0f, .pitch = 0, .yaw = 0 };
 
@@ -62,6 +63,11 @@ void update_analog_cam(Camera* c) {
         analog_cam_active = true;
     }
     
+    if (analog_cam_skip_once) {
+        analog_cam_active = false;
+        analog_cam_skip_once = false;
+    }
+
     // Record the Z targeting state.
     prev_targeting_held = targeting_held;
 
@@ -1872,4 +1878,19 @@ void analog_cam_post_play_update(PlayState* play) {
         active_cam->inputDir.x = analog_camera_pos.pitch;
         active_cam->inputDir.y = analog_camera_pos.yaw + DEG_TO_BINANG(180);
     }
+}
+
+bool get_analog_cam_active() {
+    return analog_cam_active;
+}
+
+void set_analog_cam_active(bool is_active) {
+    analog_cam_active = is_active;
+}
+
+// Calling this will avoid analog cam taking over for the following game loop.
+// E.g. using left stick inputs while in a deku flower taking priority over right stick.
+void skip_analog_cam_once() {
+    analog_cam_skip_once = true;
+    analog_cam_active = false;
 }

--- a/patches/camera_patches.c
+++ b/patches/camera_patches.c
@@ -1894,10 +1894,3 @@ void skip_analog_cam_once() {
     analog_cam_skip_once = true;
     analog_cam_active = false;
 }
-
-// Calling this will avoid analog cam taking over for the following game loop.
-// E.g. using left stick inputs while in a deku flower taking priority over right stick.
-void skip_analog_cam_once() {
-    analog_cam_skip_once = true;
-    analog_cam_active = false;
-}


### PR DESCRIPTION
#279 
Since `analog_cam_active` is static to `camera_patches.c`, I added a getter/setter for that var. The main function I patches only controls yaw while inside of a deku flower.