### PR TITLE
Start the Wart boss fight if the player looks up with analog cam

### DIFF
--- a/patches/syms.ld
+++ b/patches/syms.ld
@@ -14,6 +14,7 @@ D_808DE5B0 = 0x808DE5B0;
 sHappyMaskSalesmanAnimationInfo = 0x80AD22C0;
 D_808890F0 = 0x808890F0;
 D_8088911C = 0x8088911C;
+D_809EE4D0 = 0x809EE4D0;
 
 /* Dummy addresses that get recompiled into function calls */
 recomp_puts = 0x8F000000;


### PR DESCRIPTION
Fixes #281 

The changes I've made are:
- When analog cam is enabled, do not require the player to be in first person mode to start the fight. 
- When analog cam is enabled, use a different maximum angle to determine whether the fight starts. Otherwise, you have to stand in the corner in order to be able to start the fight.

https://github.com/Zelda64Recomp/Zelda64Recomp/assets/15913880/4542f27f-028f-4702-9216-37434d8d4132

