### PR TITLE
Init auto cam when spike rolling

### DIFF
--- a/patches/camera_patches.c
+++ b/patches/camera_patches.c
@@ -1884,6 +1884,10 @@ bool get_analog_cam_active() {
     return analog_cam_active;
 }
 
+void set_analog_cam_active(bool isActive) {
+    analog_cam_active = isActive;
+}
+
 // Calling this will avoid analog cam taking over for the following game loop.
 // E.g. using left stick inputs while in a deku flower taking priority over right stick.
 void skip_analog_cam_once() {


### PR DESCRIPTION
Note: based off of #306 due to related code changes, i will rebase after it is merged.

Pretty simple, I just set analog camera to not be active if you start spike rolling. 