### PR TITLE
CI: Split workflow execution paths

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,24 +1,11 @@
 name: validate
 on:
-  push:
-    branches:
-      - dev
-  pull_request:
-    types: [opened, synchronize]
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  workflow_call:
+    secrets:
+      ZRE_REPO_WITH_PAT:
+        required: true
 jobs:
-  authorize:
-    environment:
-      ${{ github.event_name == 'pull_request_target' &&
-      github.event.pull_request.head.repo.full_name != github.repository &&
-      'external' || 'internal' }}
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo ✓
   build-linux:
-    needs: authorize
     runs-on: ${{ matrix.arch == 'x64' && matrix.os || format('blaze/{0}', matrix.os) }}
     strategy:
       matrix:
@@ -107,7 +94,6 @@ jobs:
           name: Zelda64Recompiled-AppImage-${{ runner.arch }}-${{ matrix.type }}
           path: Zelda64Recompiled-*.AppImage
   build-windows:
-    needs: authorize
     runs-on: windows-latest
     strategy:
       matrix:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,6 +4,9 @@ on:
     secrets:
       ZRE_REPO_WITH_PAT:
         required: true
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   build-linux:
     runs-on: ${{ matrix.arch == 'x64' && matrix.os || format('blaze/{0}', matrix.os) }}

--- a/.github/workflows/validate_external.yml
+++ b/.github/workflows/validate_external.yml
@@ -2,12 +2,9 @@ name: validate-external
 on:
   pull_request_target:
     types: [opened, synchronize]
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 jobs:
   authorize:
-    # if: github.repository != github.event.pull_request.head.repo.full_name
+    if: github.repository != github.event.pull_request.head.repo.full_name
     environment:
       ${{ github.event_name == 'pull_request_target' &&
       github.event.pull_request.head.repo.full_name != github.repository &&

--- a/.github/workflows/validate_external.yml
+++ b/.github/workflows/validate_external.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo ✓
-  external:
+  build:
     needs: authorize
     uses: ./.github/workflows/validate.yml
     secrets:

--- a/.github/workflows/validate_external.yml
+++ b/.github/workflows/validate_external.yml
@@ -1,0 +1,22 @@
+name: validate
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  authorize:
+    if: github.repository != github.event.pull_request.head.repo.full_name
+    environment:
+      ${{ github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      'external' || 'internal' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ✓
+  build:
+    needs: authorize
+    uses: ./.github/workflows/validate.yml
+    secrets:
+      ZRE_REPO_WITH_PAT: ${{ secrets.ZRE_REPO_WITH_PAT }}

--- a/.github/workflows/validate_external.yml
+++ b/.github/workflows/validate_external.yml
@@ -1,4 +1,4 @@
-name: validate
+name: validate-external
 on:
   pull_request_target:
     types: [opened, synchronize]

--- a/.github/workflows/validate_external.yml
+++ b/.github/workflows/validate_external.yml
@@ -7,7 +7,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   authorize:
-    if: github.repository != github.event.pull_request.head.repo.full_name
+    # if: github.repository != github.event.pull_request.head.repo.full_name
     environment:
       ${{ github.event_name == 'pull_request_target' &&
       github.event.pull_request.head.repo.full_name != github.repository &&
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo ✓
-  build:
+  external:
     needs: authorize
     uses: ./.github/workflows/validate.yml
     secrets:

--- a/.github/workflows/validate_internal.yml
+++ b/.github/workflows/validate_internal.yml
@@ -5,9 +5,6 @@ on:
       - dev
   pull_request:
     types: [opened, synchronize]
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 jobs:
   internal:
     if: github.repository == github.event.pull_request.head.repo.full_name

--- a/.github/workflows/validate_internal.yml
+++ b/.github/workflows/validate_internal.yml
@@ -9,7 +9,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
-  build:
+  internal:
     if: github.repository == github.event.pull_request.head.repo.full_name
     uses: ./.github/workflows/validate.yml
     secrets: inherit

--- a/.github/workflows/validate_internal.yml
+++ b/.github/workflows/validate_internal.yml
@@ -1,0 +1,15 @@
+name: validate
+on:
+  push:
+    branches:
+      - dev
+  pull_request:
+    types: [opened, synchronize]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  build:
+    if: github.repository == github.event.pull_request.head.repo.full_name
+    uses: ./.github/workflows/validate.yml
+    secrets: inherit

--- a/.github/workflows/validate_internal.yml
+++ b/.github/workflows/validate_internal.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     types: [opened, synchronize]
 jobs:
-  internal:
+  build:
     if: github.repository == github.event.pull_request.head.repo.full_name
     uses: ./.github/workflows/validate.yml
     secrets: inherit

--- a/.github/workflows/validate_internal.yml
+++ b/.github/workflows/validate_internal.yml
@@ -1,4 +1,4 @@
-name: validate
+name: validate-internal
 on:
   push:
     branches:


### PR DESCRIPTION
Splits the workflows into two groups:
- internal: runs when source is this repository - uses branch workflow files
- external: uses deployments to request approval and therefore safely use secrets - uses dev branch workflow files

### internal
<img width="853" alt="Screenshot 2024-06-01 at 23 34 16" src="https://github.com/Zelda64Recomp/Zelda64Recomp/assets/2475932/8cdeec52-85d9-400d-ad78-b1dfd94b8c89">

### External
<img width="922" alt="Screenshot 2024-06-01 at 23 34 37" src="https://github.com/Zelda64Recomp/Zelda64Recomp/assets/2475932/2a3de164-a330-482c-943a-02e5300843bf">
