### PR TITLE
CI: Enable internal workflow for pushes on dev

### DIFF
--- a/.github/workflows/validate_internal.yml
+++ b/.github/workflows/validate_internal.yml
@@ -7,6 +7,6 @@ on:
     types: [opened, synchronize]
 jobs:
   build:
-    if: github.repository == github.event.pull_request.head.repo.full_name
+    if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
     uses: ./.github/workflows/validate.yml
     secrets: inherit


### PR DESCRIPTION
I realized that the if check was making it skip the workflow when the action was created due to a push to dev. This enables that