### PR TITLE
build: ensure assets are copied to cmake binary directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,6 +250,12 @@ if (CMAKE_SYSTEM_NAME MATCHES "Linux")
     target_link_libraries(Zelda64Recompiled PRIVATE "-latomic -static-libstdc++" ${CMAKE_DL_LIBS} Threads::Threads)
 endif()
 
+add_custom_command(
+    TARGET Zelda64Recompiled PRE_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory_if_different ${CMAKE_SOURCE_DIR}/assets ${CMAKE_CURRENT_BINARY_DIR}/assets
+    COMMENT "Copying assets if different"
+)
+
 target_link_libraries(Zelda64Recompiled PRIVATE
     PatchesLib
     RecompiledFuncs


### PR DESCRIPTION
this prevents needing to manually copy assets over to avoid a "Document for menu not loaded!" error

i haven't done a deep dive into how this impacts ci, but it seems as though the workflows there interact with the build directory on a file-by-file basis when packing so i'm thinking this is effectively a dev env only change