### PR TITLE
add scripts to simplify dev env setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,13 @@ rt64.log
 
 node_modules/
 
-# Recompiler Linux binary
+# Recompiler Linux binaries
 N64Recomp
+RSPRecomp
+
+# Developer environment setup directories
+elf_generating_decomp
+recomp_for_zelda
+
+# macOS specific directory information file
 .DS_Store

--- a/build-recomp-binaries.sh
+++ b/build-recomp-binaries.sh
@@ -1,0 +1,11 @@
+mkdir recomp_for_zelda
+cd recomp_for_zelda
+git clone https://github.com/N64Recomp/N64Recomp.git
+cd N64Recomp
+git checkout 8dfed04919b7bfdd0fd34ff049eed7020dea0d71
+git submodule update --init --recursive
+cmake -DCMAKE_BUILD_TYPE=Release -G Ninja -S . -B cmake-build
+cmake --build cmake-build --config Release --target N64Recomp -j$(nproc)
+cmake --build cmake-build --config Release --target RSPRecomp -j$(nproc)
+cp cmake-build/N64Recomp ../../
+cp cmake-build/RSPRecomp ../../

--- a/generate-elf-and-uncompressed-rom.sh
+++ b/generate-elf-and-uncompressed-rom.sh
@@ -1,0 +1,38 @@
+# todo: check for and verify correct baserom exists
+
+mkdir -p elf_generating_decomp
+cd elf_generating_decomp
+
+# clone decomp
+git clone https://github.com/zeldaret/mm.git
+
+# enter the decomp directory
+cd mm
+
+# checkout the required commit of decomp to generate the elf
+git checkout 23beee0717364de43ca9a82957cc910cf818de90
+
+# cherry pick the disasm.py fix
+git cherry-pick 3b8db093f6f9cfb5850a7100ba8aff0c1b099e42
+
+# copy the baserom into the decomp directory
+cp ../../baserom.mm.us.rev1.z64 .
+
+# create a python virtual environment to install decomp deps
+python3 -m venv .mm-env
+
+# activate the venv
+source .mm-env/bin/activate 
+
+# install decomp deps
+pip install -r requirements.txt
+
+# generate the elf/decompressed rom
+make init -j$(nproc)
+
+# deactivate the venv
+deactivate
+
+# copy the elf and uncompressed rom to Zelda64Recomp repo root
+cp ./mm.us.rev1.rom_uncompressed.elf ../../
+cp ./mm.us.rev1.rom_uncompressed.z64 ../../

--- a/generate-recomp-c-code.sh
+++ b/generate-recomp-c-code.sh
@@ -1,0 +1,3 @@
+./N64Recomp us.rev1.toml
+./RSPRecomp aspMain.us.rev1.toml
+./RSPRecomp njpgdspMain.us.rev1.toml


### PR DESCRIPTION
when pulling latest dev i ran into a couple issues and decided to just do a fresh clone, and decided manually following the `BUILDING.md` instructions wasn't something i wanted to do again

i made a couple scripts so instead i could just copy `baserom.mm.us.rev1.z64` into my repo checkout directory and run
```sh
./generate-elf-and-uncompressed-rom.sh
./build-recomp-binaries.sh
./generate-recomp-c-code.sh
```

i considered making custom cmake targets for this instead, but wasn't sure if it made sense for developers on windows to need to run certain cmake targets in WSL and others in windows

i figure with this a windows dev could just run the 3 scripts in WSL and then interact with Zelda64Recomp in windows land, but i could understand the argument that RSPRecomp and N64Recomp should be built as native windows binaries and the recompiled c should be generated in windows

putting this up as a draft mostly to start a conversation, my goal here is just to simplify dev env setup to lower the barrier of entry for contributions