### PR TITLE
fix: enable key repeat in rmlui menu

### DIFF
--- a/src/game/input.cpp
+++ b/src/game/input.cpp
@@ -102,8 +102,9 @@ bool sdl_event_filter(void* userdata, SDL_Event* event) {
         {
             SDL_KeyboardEvent* keyevent = &event->key;
 
-            // Skip repeated events.
-            if (event->key.repeat) {
+            // Skip repeated events when not in the menu
+            if (recompui::get_current_menu() == recompui::Menu::None &&
+                event->key.repeat) {
                 break;
             }
 


### PR DESCRIPTION
when looking into https://github.com/Zelda64Recomp/Zelda64Recomp/issues/192 i was curious as to why my initial thoughts here https://github.com/Zelda64Recomp/Zelda64Recomp/issues/192#issuecomment-2119481150 didn't fully match up with what i was experiencing.

if this was purely a "controller button press events are translated into keypress events and only happen once" issue, then i would expect this to not be an issue when navigating the rmlui menu using a keyboard

however, i experienced the exact same behavior when navigating using the keyboard as i did when using a controller. i tested out a few of the rmlui sample applications and they all seemed to respect holding a key down, so i figured something must be preventing that on the Zelda64Recomp side of things

after a little bit of digging i found that all the sdl repeat events for keys were being filtered out, both in and out of the rmlui menu. i added a check to only filter out those events when the menu isn't open, and sliders feel great on keyboard now