### PR TITLE
feat: support portable mode

### DIFF
--- a/.github/linux/appimage.sh
+++ b/.github/linux/appimage.sh
@@ -26,6 +26,12 @@ cp .github/linux/Zelda64Recompiled.desktop AppDir/
 mv squashfs-root/ deploy
 ./deploy/AppRun --appdir=AppDir/ -d AppDir/Zelda64Recompiled.desktop -i AppDir/Zelda64Recompiled.png -e AppDir/usr/bin/Zelda64Recompiled --plugin gtk
 sed -i 's/exec/#exec/g' AppDir/AppRun
-echo 'cd "$this_dir"/usr/bin/' >> AppDir/AppRun
-echo './Zelda64Recompiled' >> AppDir/AppRun
+echo 'if [ -f "portable.txt" ]; then' >> AppDir/AppRun
+echo '    APP_FOLDER_PATH=$PWD' >> AppDir/AppRun
+echo '    cd "$this_dir"/usr/bin/' >> AppDir/AppRun
+echo '    APP_FOLDER_PATH=$APP_FOLDER_PATH ./Zelda64Recompiled' >> AppDir/AppRun
+echo 'else' >> AppDir/AppRun
+echo '    cd "$this_dir"/usr/bin/' >> AppDir/AppRun
+echo '    ./Zelda64Recompiled' >> AppDir/AppRun
+echo 'fi' >> AppDir/AppRun
 ./deploy/usr/bin/linuxdeploy-plugin-appimage --appdir=AppDir

--- a/src/game/config.cpp
+++ b/src/game/config.cpp
@@ -129,6 +129,11 @@ namespace recomp {
 }
 
 std::filesystem::path zelda64::get_app_folder_path() {
+   // directly check for portable.txt (windows and native linux binary)    
+   if (std::filesystem::exists("portable.txt")) {
+       return std::filesystem::current_path();
+   }
+
    std::filesystem::path recomp_dir{};
 
 #if defined(_WIN32)
@@ -141,6 +146,11 @@ std::filesystem::path zelda64::get_app_folder_path() {
 
    CoTaskMemFree(known_path);
 #elif defined(__linux__)
+   // check for APP_FOLDER_PATH env var used by AppImage
+   if (getenv("APP_FOLDER_PATH") != nullptr) {
+       return std::filesystem::path{getenv("APP_FOLDER_PATH")};
+   }
+
    const char *homedir;
 
    if ((homedir = getenv("HOME")) == nullptr) {


### PR DESCRIPTION
this implements the suggested `portable.txt` solution to https://github.com/Zelda64Recomp/Zelda64Recomp/issues/27 proposed here https://github.com/Zelda64Recomp/Zelda64Recomp/issues/27#issuecomment-2105407975

i have tested this on linux (both native binary and appimage, both running directly and adding to steam as a non-steam game), but i have not tested this on windows at all

i feel like there is likely a cleaner way to handle the appimage oddities so if anyone has suggestions on that front i'm all ears