### PR TITLE
wip: only show prompt

### DIFF
--- a/assets/config_menu.rml
+++ b/assets/config_menu.rml
@@ -34,7 +34,7 @@
 	<!-- <handle move_target="#document"> -->
 		<div id="window" class="rmlui-window rmlui-window--hidden" style="display:flex; flex-flow: column; background-color:rgba(0,0,0,0)" onkeydown="config_keydown">
 			<div class="centered-page" onclick="close_config_menu_backdrop">
-				<div class="centered-page__modal">
+				<div data-model="config_menu_model" data-visible="!hide_for_prompt" class="centered-page__modal">
 					<tabset class="tabs" id="config_tabset">
 						<tab class="tab" autofocus id="tab_general">
 							<div>General</div>

--- a/src/game/input.cpp
+++ b/src/game/input.cpp
@@ -155,10 +155,6 @@ bool sdl_event_filter(void* userdata, SDL_Event* event) {
             return true;
         }
 
-        if (recompui::get_current_menu() != recompui::Menu::Config) {
-            recompui::set_current_menu(recompui::Menu::Config);
-        }
-
         zelda64::open_quit_game_prompt();
         recompui::activate_mouse();
         break;


### PR DESCRIPTION
i'm definitely still in the early learning stages with rmlui but i think i'm close to figuring out a solution for https://github.com/Zelda64Recomp/Zelda64Recomp/issues/369

from a behavior stand point i still need to figure out how to get it to not have a split second flash of the menu after cancelling the prompt

[Screencast from 2024-06-05 05-57-50.webm](https://github.com/Zelda64Recomp/Zelda64Recomp/assets/70942617/ac464a20-7148-43e1-963d-f99c5a78f573)

from a code stand point i don't like that i threw a global bool in there right above `open_quit_game_prompt`, but i didn't want to dive too far into modifying the callback lambdas in `open_prompt` before figuring out if i was heading in an overall reasonable direction or not