### PR TITLE
ci: download sdl from gh release url

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -37,7 +37,7 @@ jobs:
           # Enable ccache
           export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
 
-          wget https://www.libsdl.org/release/SDL2-2.26.1.tar.gz
+          wget https://github.com/libsdl-org/SDL/releases/download/release-2.26.1/SDL2-2.26.1.tar.gz
           tar -xzf SDL2-2.26.1.tar.gz
           cd SDL2-2.26.1
           ./configure


### PR DESCRIPTION
https://github.com/Zelda64Recomp/Zelda64Recomp/pull/378 doesn't seem to be working, not sure what's up with the libsdl.org certs but i figure gh runners are likely to have the appropriate certs for downloading from gh release urls (verified by running wget locally using the libsdl.org url and getting a cert error, then running wget using the gh release url and having it work