### PR TITLE
Update SDL2 version for remaining workflows

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,7 +5,7 @@ on:
       SDL2_VERSION:
         type: string
         required: false
-        default: '2.28.5'
+        default: '2.30.3'
       N64RECOMP_COMMIT:
         type: string
         required: false


### PR DESCRIPTION
This updates the SDL2 version for the remaining workflows. Windows & ARM64 Linux will use this env var.