### PR TITLE
Update N64ModernRuntime and add debug game thread naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ node_modules/
 
 # Recompiler Linux binary
 N64Recomp
+RSPRecomp
 .DS_Store
 
 # Controller mappings file

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -356,6 +356,10 @@ namespace zelda64 {
                     case 254:
                         name += "VIMGR";
                         break;
+
+                    default:
+                        name += std::to_string(t->id);
+                        break;
                 }
                 break;
 
@@ -371,6 +375,10 @@ namespace zelda64 {
 
                     case 127:
                         name += "FAULT";
+                        break;
+
+                    default:
+                        name += std::to_string(t->id);
                         break;
                 }
                 break;
@@ -504,7 +512,17 @@ int main(int argc, char** argv) {
         .get_game_thread_name = zelda64::get_game_thread_name,
     };
 
-    recomp::start({}, rsp_callbacks, renderer_callbacks, audio_callbacks, input_callbacks, gfx_callbacks, thread_callbacks, error_handling_callbacks, threads_callbacks);
+    recomp::start(
+        {},
+        rsp_callbacks,
+        renderer_callbacks,
+        audio_callbacks,
+        input_callbacks,
+        gfx_callbacks,
+        thread_callbacks,
+        error_handling_callbacks,
+        threads_callbacks
+    );
 
     NFD_Quit();
 

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -341,6 +341,81 @@ std::vector<recomp::GameEntry> supported_games = {
     },
 };
 
+// TODO: move somewhere else
+namespace zelda64 {
+    std::string get_game_thread_name(const OSThread* t) {
+        std::string name = "[Game] ";
+
+        switch (t->id) {
+            case 0:
+                switch (t->priority) {
+                    case 150:
+                        name += "PIMGR";
+                        break;
+
+                    case 254:
+                        name += "VIMGR";
+                        break;
+                }
+                break;
+
+            case 1:
+                name += "IDLE";
+                break;
+
+            case 2:
+                switch (t->priority) {
+                    case 5:
+                        name += "SLOWLY";
+                        break;
+
+                    case 127:
+                        name += "FAULT";
+                        break;
+                }
+                break;
+
+            case 3:
+                name += "MAIN";
+                break;
+
+            case 4:
+                name += "GRAPH";
+                break;
+
+            case 5:
+                name += "SCHED";
+                break;
+
+            case 7:
+                name += "PADMGR";
+                break;
+
+            case 10:
+                name += "AUDIOMGR";
+                break;
+
+            case 13:
+                name += "FLASHROM";
+                break;
+
+            case 18:
+                name += "DMAMGR";
+                break;
+
+            case 19:
+                name += "IRQMGR";
+                break;
+
+            default:
+                name += std::to_string(t->id);
+                break;
+        }
+
+        return name;
+    }
+}
+
 
 int main(int argc, char** argv) {
 
@@ -425,7 +500,11 @@ int main(int argc, char** argv) {
         .message_box = recompui::message_box,
     };
 
-    recomp::start({}, rsp_callbacks, renderer_callbacks, audio_callbacks, input_callbacks, gfx_callbacks, thread_callbacks, error_handling_callbacks);
+    ultramodern::threads::callbacks_t threads_callbacks{
+        .get_game_thread_name = zelda64::get_game_thread_name,
+    };
+
+    recomp::start({}, rsp_callbacks, renderer_callbacks, audio_callbacks, input_callbacks, gfx_callbacks, thread_callbacks, error_handling_callbacks, threads_callbacks);
 
     NFD_Quit();
 


### PR DESCRIPTION
### Relevant N64ModernRuntime changes
- Use https for submodules instead of ssh
- Remove legacy "permanent" and "temporary" threads tagging.
- Allow to provide custom names to game threads via callbacks.
For full changes check [here](https://github.com/N64Recomp/N64ModernRuntime/compare/0c1811ca6f8291c6608f1d6626a73e863902ece9...ce68e96c171f7f036e29f539e22a604da04af824)

### Changes on this repo
- Give meaningful names to all MM threads.
- Add RSPRecomp to gitignore

This is how the newly named game threads looks like:
![image](https://github.com/Zelda64Recomp/Zelda64Recomp/assets/7416381/267609cf-5d6d-4027-93b4-cca78edfaa03)

