### PR TITLE
add option to skip Song of Soaring cutscene

### DIFF
--- a/patches/skip_sos.c
+++ b/patches/skip_sos.c
@@ -1,0 +1,29 @@
+#include "patches.h"
+
+#include "overlays/actors/ovl_En_Test7/z_en_test7.h"
+
+#define THIS ((EnTest7*)thisx)
+
+void func_80AF118C(PlayState* play, OwlWarpFeather* feathers, EnTest7* this, s32 arg3, s32 arg4); // EnTest7_UpdateFeathers
+void func_80AF2350(EnTest7* this, PlayState* play); // EnTest7_WarpCsWarp
+
+void EnTest7_Update(Actor* thisx, PlayState* play) {
+    EnTest7* this = THIS;
+
+    this->actionFunc(this, play);
+
+    if (this->playerCamFunc != NULL) {
+        this->playerCamFunc(this, play);
+    }
+
+    this->timer++;
+
+    func_80AF118C(play, this->feathers, this, (this->flags & OWL_WARP_FLAGS_8) != 0,
+                           (this->flags & OWL_WARP_FLAGS_10) != 0);
+
+    // @recomp Allow skipping the Song of Soaring cutscene.
+    Input* input = CONTROLLER1(&play->state);
+    if (CHECK_BTN_ANY(input->press.button, BTN_A | BTN_B) && (OWL_WARP_CS_GET_OCARINA_MODE(&this->actor) != ENTEST7_ARRIVE)) {
+        func_80AF2350(thisx, play);
+    }
+}


### PR DESCRIPTION
This pull request adds an option to skip the Song of Soaring cutscene with the A button.

https://github.com/Zelda64Recomp/Zelda64Recomp/assets/59661841/670a6963-9ea9-4fb4-9da7-2e6f11875dd5

This closes #396.