### PR TITLE
fix: use sdl userevent to set await_stick_return when scanning for input

### DIFF
--- a/src/game/input.cpp
+++ b/src/game/input.cpp
@@ -192,9 +192,23 @@ bool sdl_event_filter(void* userdata, SDL_Event* event) {
             SDL_ControllerAxisEvent* axis_event = &event->caxis;
             float axis_value = axis_event->value * (1/32768.0f);
             if (axis_value > axis_threshold) {
+                SDL_Event set_stick_return_event;
+                set_stick_return_event.type = SDL_USEREVENT;
+                set_stick_return_event.user.code = axis_event->axis;
+                set_stick_return_event.user.data1 = nullptr;
+                set_stick_return_event.user.data2 = nullptr;
+                recompui::queue_event(set_stick_return_event);
+                
                 set_scanned_input({(uint32_t)InputType::ControllerAnalog, axis_event->axis + 1});
             }
             else if (axis_value < -axis_threshold) {
+                SDL_Event set_stick_return_event;
+                set_stick_return_event.type = SDL_USEREVENT;
+                set_stick_return_event.user.code = axis_event->axis;
+                set_stick_return_event.user.data1 = nullptr;
+                set_stick_return_event.user.data2 = nullptr;
+                recompui::queue_event(set_stick_return_event);
+
                 set_scanned_input({(uint32_t)InputType::ControllerAnalog, -axis_event->axis - 1});
             }
         } else {

--- a/src/ui/ui_renderer.cpp
+++ b/src/ui/ui_renderer.cpp
@@ -1350,6 +1350,13 @@ void draw_hook(RT64::RenderCommandList* command_list, RT64::RenderFramebuffer* s
                 non_mouse_interacted = true;
                 kb_interacted = true;
                 break;
+            case SDL_EventType::SDL_USEREVENT:
+                if (cur_event.user.code == SDL_GameControllerAxis::SDL_CONTROLLER_AXIS_LEFTY) {
+                    ui_context->rml.await_stick_return_y = true;
+                } else if (cur_event.user.code == SDL_GameControllerAxis::SDL_CONTROLLER_AXIS_LEFTX) {
+                    ui_context->rml.await_stick_return_x = true;
+                }
+                break;
             case SDL_EventType::SDL_CONTROLLERAXISMOTION:
                 SDL_ControllerAxisEvent* axis_event = &cur_event.caxis;
                 if (axis_event->axis != SDL_GameControllerAxis::SDL_CONTROLLER_AXIS_LEFTY && axis_event->axis != SDL_GameControllerAxis::SDL_CONTROLLER_AXIS_LEFTX) {


### PR DESCRIPTION
fixes https://github.com/Zelda64Recomp/Zelda64Recomp/issues/411

this adds a 300ms debounce to axis events after scanning since they're being fired off constantly 