### PR TITLE
Remove decomp elf dependency and automate patch relocations

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,7 +9,7 @@ on:
       N64RECOMP_COMMIT:
         type: string
         required: false
-        default: '388c16c13f7ab5f18ea41da9c58f5b6478498f57'
+        default: 'ba4aede49c9a5302ecfc1fa599f7acc3925042f9'
       DXC_CHECKSUM:
         type: string
         required: false

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,7 +9,7 @@ on:
       N64RECOMP_COMMIT:
         type: string
         required: false
-        default: 'd30d85bdfb711d05443c5d3e9a52cdd766ba1e49'
+        default: '388c16c13f7ab5f18ea41da9c58f5b6478498f57'
       DXC_CHECKSUM:
         type: string
         required: false

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,7 +9,7 @@ on:
       N64RECOMP_COMMIT:
         type: string
         required: false
-        default: '2a2df89349ff25a3afb3a09617deb3a166efe2f3'
+        default: 'a384076f20caa01b0240d342e41f0f20d75bb95c'
       DXC_CHECKSUM:
         type: string
         required: false

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,7 +9,7 @@ on:
       N64RECOMP_COMMIT:
         type: string
         required: false
-        default: 'a384076f20caa01b0240d342e41f0f20d75bb95c'
+        default: 'd30d85bdfb711d05443c5d3e9a52cdd766ba1e49'
       DXC_CHECKSUM:
         type: string
         required: false

--- a/.gitmodules
+++ b/.gitmodules
@@ -21,4 +21,4 @@
 	url = https://github.com/N64Recomp/N64ModernRuntime.git
 [submodule "Zelda64RecompSyms"]
 	path = Zelda64RecompSyms
-	url = https://github.com:Zelda64Recomp/Zelda64RecompSyms
+	url = https://github.com/Zelda64Recomp/Zelda64RecompSyms

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "lib/N64ModernRuntime"]
 	path = lib/N64ModernRuntime
 	url = https://github.com/N64Recomp/N64ModernRuntime.git
+[submodule "Zelda64RecompSyms"]
+	path = Zelda64RecompSyms
+	url = https://github.com:Zelda64Recomp/Zelda64RecompSyms

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,13 +1,8 @@
 # Building Guide
 
-> [!NOTE]  
-> The need for an elf file from the Majora's Mask decompilation is temporary and will be removed in the future.
+This guide will help you build the project on your local machine. The process will require you to provide a decompressed ROM of the US version of the game.
 
-This guide will help you build the project on your local machine. The process will require you to provide two items:
-- A decompressed ROM of the US version of the game.
-- An elf file created from [this commit](https://github.com/zeldaret/mm/tree/23beee0717364de43ca9a82957cc910cf818de90) of the Majora's Mask decompilation.
-
-These steps cover: acquiring these, running the required processes and finally building the project.
+These steps cover: decompressing the ROM, running the recompiler and finally building the project.
 
 ## 1. Clone the Zelda64Recomp Repository
 This project makes use of submodules so you will need to clone the repository with the `--recurse-submodules` flag.
@@ -40,20 +35,14 @@ The other tool necessary will be `make` which can be installe via [Chocolatey](h
 choco install make
 ```
 
-## 3. Creating the ELF file & decompressed ROM
-You will need to build [this commit](https://github.com/zeldaret/mm/tree/23beee0717364de43ca9a82957cc910cf818de90) of the Majora's Mask decompilation. Follow their build instructions to generate the ELF file and decompressed ROM. However, while building you may get the following build error:
-```bash
-RuntimeError: 'jr' instruction does not have an 'jump label' field
-```
+## 3. Decompressing the target ROM
+You will need to decompress the NTSC-U N64 Majora's Mask ROM (sha1: d6133ace5afaa0882cf214cf88daba39e266c078) before running the recompiler.
 
-To fix this you will have to modify the problematic file `tools/disasm/disasm.py` at line 1115. This issue is due to a bug in this specific commit of the decomp project and will be resolved once Zelda64Recomp is updated to a more recent commit. To fix it, replace the line:
-```diff
-- elif insn.isJump():
-+ elif insn.isJumpWithAddress():
-```
+There are a few tools that can do it:
+* This python script from the Majora's Mask decompilation project: https://github.com/zeldaret/mm/blob/main/tools/buildtools/decompress_baserom.py
+* https://github.com/z64tools/z64decompress
 
-Upon successful build it will generate the two required files. Copy them to the root of the Zelda64Recomp repository:
-- `mm.us.rev1.rom_uncompressed.elf`
+Regardless of which method you use, copy the decompressed ROM to the root of the Zelda64Recomp repository with this filename:
 - `mm.us.rev1.rom_uncompressed.z64`
 
 ## 4. Generating the C code
@@ -71,7 +60,9 @@ After that, go back to the repository root, and run the following commands:
 
 Finally, you can build the project! :rocket:
 
-On Windows, you can open the repository folder with Visual Studio, and you'll be able to `[build / run / debug]` the project from there. If you prefer the commandline or you're on a Unix platform you can build the project using CMake:
+On Windows, you can open the repository folder with Visual Studio, and you'll be able to `[build / run / debug]` the project from there.
+
+If you prefer the command line or you're on a Unix platform you can build the project using CMake:
 
 ```bash
 cmake -S . -B build-cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -G Ninja -DCMAKE_BUILD_TYPE=Release # or Debug if you want to debug
@@ -80,7 +71,7 @@ cmake --build build-cmake --target Zelda64Recompiled -j$(nproc) --config Release
 
 ## 6. Success
 
-Voilà! You should now have a `Zelda64Recompiled` file in the `build-cmake` directory!
+Voilà! You should now have a `Zelda64Recompiled` executable in the build directory! If you used Visual Studio this will be `out/build/x64-[Configuration]` and if you used the provided CMake commands then this will be `build-cmake`. You will need to run the executable out of the root folder of this project or copy the assets folder to the build folder to run it.
 
 > [!IMPORTANT]  
 > In the game itself, you should be using a standard ROM, not the decompressed one.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ endif()
 add_custom_target(PatchesBin
     COMMAND ${CMAKE_COMMAND} -E env CC=${PATCHES_C_COMPILER} LD=${PATCHES_LD} OBJCOPY=${PATCHES_OBJCOPY} make
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/patches
-    BYPRODUCTS ${CMAKE_SOURCE_DIR}/patches/patches.bin
+    BYPRODUCTS ${CMAKE_SOURCE_DIR}/patches/patches.elf
 )
 
 # Generate patches_bin.c from patches.bin
@@ -104,15 +104,16 @@ add_custom_command(OUTPUT ${CMAKE_SOURCE_DIR}/RecompiledPatches/patches_bin.c
     DEPENDS ${CMAKE_SOURCE_DIR}/patches/patches.bin
 )
 
-# Recompile patches elf into patches.c
+# Recompile patches elf into patches.c and patches.bin
 add_custom_command(OUTPUT
+                       ${CMAKE_SOURCE_DIR}/patches/patches.bin
                        ${CMAKE_SOURCE_DIR}/RecompiledPatches/patches.c
                        ${CMAKE_SOURCE_DIR}/RecompiledPatches/recomp_overlays.inl
                        ${CMAKE_SOURCE_DIR}/RecompiledPatches/funcs.h
                    # TODO: Look into why modifying patches requires two builds to take
                    COMMAND ./N64Recomp patches.toml
                    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-                   DEPENDS ${CMAKE_SOURCE_DIR}/patches/patches.bin
+                   DEPENDS ${CMAKE_SOURCE_DIR}/patches/patches.elf
 )
 
 # Download controller db file for controller support via SDL2

--- a/patches.toml
+++ b/patches.toml
@@ -5,5 +5,10 @@
 elf_path = "patches/patches.elf"
 output_func_path = "RecompiledPatches"
 single_file_output = true
-# Allow absolute symbols to be used as jump targets
+# Allow absolute symbols to be used as jump targets.
 use_absolute_symbols = true
+# Emit R_MIPS_32 relocations so they can be populated when loading the patch overlay.
+emit_mips_32_relocs = true
+# Point the recompiler at the symbol files so that it can resolve relocations during recompilation.
+func_reference_syms_file = "us.rev1.syms.toml"
+data_reference_syms_files = [ "us.rev1.datasyms.toml", "us.rev1.datasyms_static.toml" ]

--- a/patches.toml
+++ b/patches.toml
@@ -12,3 +12,5 @@ func_reference_syms_file = "Zelda64RecompSyms/mm.us.rev1.syms.toml"
 data_reference_syms_files = [ "Zelda64RecompSyms/mm.us.rev1.datasyms.toml", "Zelda64RecompSyms/mm.us.rev1.datasyms_static.toml" ]
 # Tell the recompiler to write the output binary. Doing this instead of using objcopy allows the recompiler to patch MIPS32 relocs.
 output_binary_path = "patches/patches.bin"
+# Do not emit warnings for unpaired LO16 values, as clang produces many of them.
+unpaired_lo16_warnings = false

--- a/patches.toml
+++ b/patches.toml
@@ -7,8 +7,6 @@ output_func_path = "RecompiledPatches"
 single_file_output = true
 # Allow absolute symbols to be used as jump targets.
 use_absolute_symbols = true
-# Emit R_MIPS_32 relocations so they can be populated when loading the patch overlay.
-emit_mips_32_relocs = true
 # Point the recompiler at the symbol files so that it can resolve relocations during recompilation.
 func_reference_syms_file = "Zelda64RecompSyms/mm.us.rev1.syms.toml"
 data_reference_syms_files = [ "Zelda64RecompSyms/mm.us.rev1.datasyms.toml", "Zelda64RecompSyms/mm.us.rev1.datasyms_static.toml" ]

--- a/patches.toml
+++ b/patches.toml
@@ -10,5 +10,7 @@ use_absolute_symbols = true
 # Emit R_MIPS_32 relocations so they can be populated when loading the patch overlay.
 emit_mips_32_relocs = true
 # Point the recompiler at the symbol files so that it can resolve relocations during recompilation.
-func_reference_syms_file = "us.rev1.syms.toml"
-data_reference_syms_files = [ "us.rev1.datasyms.toml", "us.rev1.datasyms_static.toml" ]
+func_reference_syms_file = "Zelda64RecompSyms/mm.us.rev1.syms.toml"
+data_reference_syms_files = [ "Zelda64RecompSyms/mm.us.rev1.datasyms.toml", "Zelda64RecompSyms/mm.us.rev1.datasyms_static.toml" ]
+# Tell the recompiler to write the output binary. Doing this instead of using objcopy allows the recompiler to patch MIPS32 relocs.
+output_binary_path = "patches/patches.bin"

--- a/patches/Makefile
+++ b/patches/Makefile
@@ -8,8 +8,8 @@ CFLAGS   := -target mips -mips2 -mabi=32 -O2 -G0 -mno-abicalls -mno-odd-spreg -m
 			-fomit-frame-pointer -ffast-math -fno-unsafe-math-optimizations -fno-builtin-memset \
 			-Wall -Wextra -Wno-incompatible-library-redeclaration -Wno-unused-parameter -Wno-unknown-pragmas -Wno-unused-variable -Wno-missing-braces -Wno-unsupported-floating-point-opt
 CPPFLAGS := -nostdinc -D_LANGUAGE_C -DMIPS -I dummy_headers -I ../lib/mm-decomp/include -I ../lib/mm-decomp/src -I ../lib/mm-decomp/assets -I../lib/rt64/include
-LDFLAGS  := -nostdlib -T patches.ld -T syms.ld --just-symbols=../mm.us.rev1.rom_uncompressed.elf --allow-multiple-definition -Map patches.map
-BINFLAGS := -O binary --remove-section=.bss --remove-section=.pad --remove-section=.text
+LDFLAGS  := -nostdlib -T patches.ld -T syms.ld -Map patches.map --unresolved-symbols=ignore-all --emit-relocs
+BINFLAGS := -O binary --only-section=.ctors --only-section=.dtors --only-section=.rodata --only-section=.data
 
 C_SRCS := $(wildcard *.c)
 C_OBJS := $(C_SRCS:.c=.o)

--- a/patches/Makefile
+++ b/patches/Makefile
@@ -2,23 +2,16 @@ TARGET = patches.elf
 
 CC      ?= clang
 LD      ?= ld.lld
-OBJCOPY ?= llvm-objcopy
 
 CFLAGS   := -target mips -mips2 -mabi=32 -O2 -G0 -mno-abicalls -mno-odd-spreg -mno-check-zero-division \
 			-fomit-frame-pointer -ffast-math -fno-unsafe-math-optimizations -fno-builtin-memset \
 			-Wall -Wextra -Wno-incompatible-library-redeclaration -Wno-unused-parameter -Wno-unknown-pragmas -Wno-unused-variable -Wno-missing-braces -Wno-unsupported-floating-point-opt
 CPPFLAGS := -nostdinc -D_LANGUAGE_C -DMIPS -I dummy_headers -I ../lib/mm-decomp/include -I ../lib/mm-decomp/src -I ../lib/mm-decomp/assets -I../lib/rt64/include
 LDFLAGS  := -nostdlib -T patches.ld -T syms.ld -Map patches.map --unresolved-symbols=ignore-all --emit-relocs
-BINFLAGS := -O binary --only-section=.ctors --only-section=.dtors --only-section=.rodata --only-section=.data
 
 C_SRCS := $(wildcard *.c)
 C_OBJS := $(C_SRCS:.c=.o)
 C_DEPS := $(C_SRCS:.c=.d)
-
-DATABIN := $(TARGET:.elf=.bin)
-
-$(DATABIN): $(TARGET)
-	$(OBJCOPY) $(BINFLAGS) $(TARGET) $@
 
 $(TARGET): $(C_OBJS) patches.ld syms.ld
 	$(LD) $(C_OBJS) $(LDFLAGS) -o $@
@@ -27,7 +20,7 @@ $(C_OBJS): %.o : %.c
 	$(CC) $(CFLAGS) $(CPPFLAGS) $< -MMD -MF $(@:.o=.d) -c -o $@
 
 clean:
-	rm -rf $(C_OBJS) $(TARGET) $(DATABIN) $(C_DEPS)
+	rm -rf $(C_OBJS) $(TARGET) $(C_DEPS)
 
 -include $(C_DEPS)
 

--- a/patches/camera_patches.c
+++ b/patches/camera_patches.c
@@ -1911,8 +1911,6 @@ void func_809EC568(Boss04* this, PlayState* play) {
     f32 y;
     f32 z;
     s32 pad;
-    // @recomp Manual relocation, TODO remove when automated.
-    u8* D_809EE4D0_relocated = (u8*)actor_relocate(&this->actor, &D_809EE4D0);
     u16 maxProjectedPosToStartFight;
 
     // @recomp Change the maximun projected position to start the fight depending on whether analog camera is enabled or not.
@@ -2059,7 +2057,7 @@ void func_809EC568(Boss04* this, PlayState* play) {
                 this->unk_2C8 = 300;
                 this->unk_2D0 = 0.0f;
                 
-                *D_809EE4D0_relocated = 1;
+                D_809EE4D0 = 1;
                 this->unk_2E2 = 60;
                 this->unk_2E0 = 93;
             }

--- a/patches/cutscene_patches.c
+++ b/patches/cutscene_patches.c
@@ -63,17 +63,13 @@ void func_80884718(EnHorse* this, PlayState* play) {
             }
 
             this->cueId = cue->id;
-            // @recomp Manual relocation, TODO remove when automated.
-            EnHorseCsFunc* D_808890F0_reloc = actor_relocate(&this->actor, D_808890F0);
-            if (D_808890F0_reloc[this->cueId] != NULL) {
-                D_808890F0_reloc[this->cueId](this, play, cue);
+            if (D_808890F0[this->cueId] != NULL) {
+                D_808890F0[this->cueId](this, play, cue);
             }
         }
 
-        // @recomp Manual relocation, TODO remove when automated.
-        EnHorseCsFunc* D_8088911C_reloc = actor_relocate(&this->actor, D_8088911C);
-        if (D_8088911C_reloc[this->cueId] != NULL) {
-            D_8088911C_reloc[this->cueId](this, play, cue);
+        if (D_8088911C[this->cueId] != NULL) {
+            D_8088911C[this->cueId](this, play, cue);
         }
     }
 }

--- a/patches/effect_patches.c
+++ b/patches/effect_patches.c
@@ -34,12 +34,7 @@ void TransitionWipe3_Draw(void* thisx, Gfx** gfxP) {
         guScale(modelView, scale, scale, 1.0f);
         gSPMatrix(gfx++, modelView, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
     }
-    // sTransWipe3DL is an overlay symbol, so its addresses need to be offset to get the actual loaded vram address.
-    // TODO remove this once the recompiler is able to handle overlay symbols automatically for patch functions.
-    ptrdiff_t reloc_offset;
-    TransitionOverlay* overlay_entry = &gTransitionOverlayTable[FBDEMO_WIPE3];
-    reloc_offset = (uintptr_t)Lib_PhysicalToVirtual(overlay_entry->loadInfo.addr) - (uintptr_t)overlay_entry->vramStart;
-    gSPDisplayList(gfx++, (Gfx*)((u8*)sTransWipe3DL + reloc_offset));
+    gSPDisplayList(gfx++, sTransWipe3DL);
     gDPPipeSync(gfx++);
     *gfxP = gfx;
 }

--- a/patches/effect_transform_tagging.c
+++ b/patches/effect_transform_tagging.c
@@ -178,15 +178,12 @@ void func_808DD3C8(Actor* thisx, PlayState* play2) {
     spB4 = false;
 
     if (this->actor.params == 3) {
-        // @recomp Manual relocation, TODO remove when the recompiler handles this automatically.
-        f32* D_808DE5B0_ptr = actor_relocate(thisx, &D_808DE5B0);
-
         temp_f0 = func_80173B48(&play->state) / 1.4e7f;
         temp_f0 = CLAMP(temp_f0, 0.0f, 1.0f);
-        Math_SmoothStepToF(D_808DE5B0_ptr, temp_f0, 0.2f, 0.1f, 0.001f);
+        Math_SmoothStepToF(&D_808DE5B0, temp_f0, 0.2f, 0.1f, 0.001f);
 
         sp68 = play->envCtx.precipitation[PRECIP_SNOW_CUR];
-        sp68 *= *D_808DE5B0_ptr;
+        sp68 *= D_808DE5B0;
 
         if ((play->envCtx.precipitation[PRECIP_SNOW_CUR] >= 32) && (sp68 < 32)) {
             sp68 = 32;
@@ -469,8 +466,7 @@ void EnClearTag_DrawEffects(Actor* thisx, PlayState* play) {
             // Apply the debris effect material if it has not already been applied.
             if (!isMaterialApplied) {
                 isMaterialApplied++;
-                // @recomp Manual relocation, TODO remove when automated.
-                gSPDisplayList(POLY_OPA_DISP++, actor_relocate(thisx, gClearTagDebrisEffectMaterialDL));
+                gSPDisplayList(POLY_OPA_DISP++, gClearTagDebrisEffectMaterialDL);
             }
 
             // Draw the debris effect.
@@ -481,8 +477,7 @@ void EnClearTag_DrawEffects(Actor* thisx, PlayState* play) {
             gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
             // @recomp Tag the matrix.
             gEXMatrixGroupDecomposedNormal(POLY_OPA_DISP++, actor_transform_id(thisx) + i, G_EX_PUSH, G_MTX_MODELVIEW, G_EX_EDIT_NONE);
-            // @recomp Manual relocation, TODO remove when automated.
-            gSPDisplayList(POLY_OPA_DISP++, actor_relocate(thisx, gClearTagDebrisEffectDL));
+            gSPDisplayList(POLY_OPA_DISP++, gClearTagDebrisEffectDL);
             // @recomp Pop the matrix tag.
             gEXPopMatrixGroup(POLY_OPA_DISP++, G_MTX_MODELVIEW);
         }
@@ -531,8 +526,7 @@ void EnClearTag_DrawEffects(Actor* thisx, PlayState* play) {
                 gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
                 // @recomp Tag the matrix.
                 gEXMatrixGroupDecomposedNormal(POLY_XLU_DISP++, actor_transform_id(thisx) + i, G_EX_PUSH, G_MTX_MODELVIEW, G_EX_EDIT_NONE);
-                // @recomp Manual relocation, TODO remove when automated.
-                gSPDisplayList(POLY_XLU_DISP++, actor_relocate(thisx, gClearTagFlashEffectGroundDL));
+                gSPDisplayList(POLY_XLU_DISP++, gClearTagFlashEffectGroundDL);
                 // @recomp Pop the matrix tag.
                 gEXPopMatrixGroup(POLY_XLU_DISP++, G_MTX_MODELVIEW);
             }
@@ -546,8 +540,7 @@ void EnClearTag_DrawEffects(Actor* thisx, PlayState* play) {
         if ((effect->type == CLEAR_TAG_EFFECT_SMOKE) || (effect->type == CLEAR_TAG_EFFECT_ISOLATED_SMOKE)) {
             // Apply the smoke effect material if it has not already been applied.
             if (!isMaterialApplied) {
-                // @recomp Manual relocation, TODO remove when automated.
-                gSPDisplayList(POLY_XLU_DISP++, actor_relocate(thisx, gClearTagFireEffectMaterialDL));
+                gSPDisplayList(POLY_XLU_DISP++, gClearTagFireEffectMaterialDL);
                 isMaterialApplied++;
             }
 
@@ -566,8 +559,7 @@ void EnClearTag_DrawEffects(Actor* thisx, PlayState* play) {
             gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
             // @recomp Tag the matrix.
             gEXMatrixGroupDecomposedNormal(POLY_XLU_DISP++, actor_transform_id(thisx) + i, G_EX_PUSH, G_MTX_MODELVIEW, G_EX_EDIT_NONE);
-            // @recomp Manual relocation, TODO remove when automated.
-            gSPDisplayList(POLY_XLU_DISP++, actor_relocate(thisx, gClearTagFireEffectDL));
+            gSPDisplayList(POLY_XLU_DISP++, gClearTagFireEffectDL);
             // @recomp Pop the matrix tag.
             gEXPopMatrixGroup(POLY_XLU_DISP++, G_MTX_MODELVIEW);
         }
@@ -580,8 +572,7 @@ void EnClearTag_DrawEffects(Actor* thisx, PlayState* play) {
         if (effect->type == CLEAR_TAG_EFFECT_FIRE) {
             // Apply the fire effect material if it has not already been applied.
             if (!isMaterialApplied) {
-                // @recomp Manual relocation, TODO remove when automated.
-                gSPDisplayList(POLY_XLU_DISP++, actor_relocate(thisx, gClearTagFireEffectMaterialDL));
+                gSPDisplayList(POLY_XLU_DISP++, gClearTagFireEffectMaterialDL);
                 gDPSetEnvColor(POLY_XLU_DISP++, 255, 215, 255, 128);
                 isMaterialApplied++;
             }
@@ -596,8 +587,7 @@ void EnClearTag_DrawEffects(Actor* thisx, PlayState* play) {
             gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
             // @recomp Tag the matrix.
             gEXMatrixGroupDecomposedNormal(POLY_XLU_DISP++, actor_transform_id(thisx) + i, G_EX_PUSH, G_MTX_MODELVIEW, G_EX_EDIT_NONE);
-            // @recomp Manual relocation, TODO remove when automated.
-            gSPDisplayList(POLY_XLU_DISP++, actor_relocate(thisx, gClearTagFireEffectDL));
+            gSPDisplayList(POLY_XLU_DISP++, gClearTagFireEffectDL);
             // @recomp Pop the matrix tag.
             gEXPopMatrixGroup(POLY_XLU_DISP++, G_MTX_MODELVIEW);
         }
@@ -623,8 +613,7 @@ void EnClearTag_DrawEffects(Actor* thisx, PlayState* play) {
             gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
             // @recomp Tag the matrix.
             gEXMatrixGroupDecomposedNormal(POLY_XLU_DISP++, actor_transform_id(thisx) + i, G_EX_PUSH, G_MTX_MODELVIEW, G_EX_EDIT_NONE);
-            // @recomp Manual relocation, TODO remove when automated.
-            gSPDisplayList(POLY_XLU_DISP++, actor_relocate(thisx, gClearTagFlashEffectDL));
+            gSPDisplayList(POLY_XLU_DISP++, gClearTagFlashEffectDL);
             // @recomp Pop the matrix tag.
             gEXPopMatrixGroup(POLY_XLU_DISP++, G_MTX_MODELVIEW);
         }
@@ -640,8 +629,7 @@ void EnClearTag_DrawEffects(Actor* thisx, PlayState* play) {
                 gDPPipeSync(POLY_XLU_DISP++);
                 gDPSetEnvColor(POLY_XLU_DISP++, (u8)effect->envColor.r, (u8)effect->envColor.g, (u8)effect->envColor.b,
                                0);
-                // @recomp Manual relocation, TODO remove when automated.
-                gSPDisplayList(POLY_XLU_DISP++, actor_relocate(thisx, gClearTagLightRayEffectMaterialDL));
+                gSPDisplayList(POLY_XLU_DISP++, gClearTagLightRayEffectMaterialDL);
                 isMaterialApplied++;
             }
 
@@ -657,8 +645,7 @@ void EnClearTag_DrawEffects(Actor* thisx, PlayState* play) {
             gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
             // @recomp Tag the matrix.
             gEXMatrixGroupDecomposedNormal(POLY_XLU_DISP++, actor_transform_id(thisx) + i, G_EX_PUSH, G_MTX_MODELVIEW, G_EX_EDIT_NONE);
-            // @recomp Manual relocation, TODO remove when automated.
-            gSPDisplayList(POLY_XLU_DISP++, actor_relocate(thisx, gClearTagLightRayEffectDL));
+            gSPDisplayList(POLY_XLU_DISP++, gClearTagLightRayEffectDL);
             // @recomp Pop the matrix tag.
             gEXPopMatrixGroup(POLY_XLU_DISP++, G_MTX_MODELVIEW);
         }

--- a/patches/fixes.c
+++ b/patches/fixes.c
@@ -8,7 +8,7 @@
 #define PAGE_BG_WIDTH (PAGE_BG_COLS * PAGE_BG_QUAD_WIDTH)
 #define PAGE_BG_HEIGHT (PAGE_BG_ROWS * PAGE_BG_QUAD_HEIGHT)
 
-#define RECOMP_PAGE_ROW_HEIGHT 14
+#define RECOMP_PAGE_ROW_HEIGHT 15
 #define RECOMP_PAGE_ROW_COUNT ((PAGE_BG_HEIGHT + RECOMP_PAGE_ROW_HEIGHT - 1) / RECOMP_PAGE_ROW_HEIGHT)
 
 extern s16* sVtxPageQuadsX[VTX_PAGE_MAX];
@@ -55,16 +55,16 @@ s16 KaleidoScope_SetPageVertices(PlayState* play, Vtx* vtx, s16 vtxPage, s16 num
 
         vtx[4 * row + 0].v.flag = vtx[4 * row + 1].v.flag = vtx[4 * row + 2].v.flag = vtx[4 * row + 3].v.flag = 0;
 
-        #define PIXEL_OFFSET ((1 << 4))
+        #define PIXEL_OFFSET 0
 
         vtx[4 * row + 0].v.tc[0] = PIXEL_OFFSET;
-        vtx[4 * row + 0].v.tc[1] = (1 << 5) + PIXEL_OFFSET;
-        vtx[4 * row + 1].v.tc[0] = PAGE_BG_WIDTH * (1 << 5) + PIXEL_OFFSET;
-        vtx[4 * row + 1].v.tc[1] = (1 << 5) + PIXEL_OFFSET;
+        vtx[4 * row + 0].v.tc[1] = PIXEL_OFFSET;
+        vtx[4 * row + 1].v.tc[0] = (PAGE_BG_WIDTH + 2 - 1) * (1 << 5) + PIXEL_OFFSET;
+        vtx[4 * row + 1].v.tc[1] = PIXEL_OFFSET;
         vtx[4 * row + 2].v.tc[0] = PIXEL_OFFSET;
-        vtx[4 * row + 2].v.tc[1] = (cur_y - next_y + 1) * (1 << 5) + PIXEL_OFFSET;
-        vtx[4 * row + 3].v.tc[0] = PAGE_BG_WIDTH * (1 << 5) + PIXEL_OFFSET;
-        vtx[4 * row + 3].v.tc[1] = (cur_y - next_y + 1) * (1 << 5) + PIXEL_OFFSET;
+        vtx[4 * row + 2].v.tc[1] = (cur_y - next_y + 1 - 1) * (1 << 5) + PIXEL_OFFSET;
+        vtx[4 * row + 3].v.tc[0] = (PAGE_BG_WIDTH + 2 - 1) * (1 << 5) + PIXEL_OFFSET;
+        vtx[4 * row + 3].v.tc[1] = (cur_y - next_y + 1 - 1) * (1 << 5) + PIXEL_OFFSET;
 
         vtx[4 * row + 0].v.cn[0] = vtx[4 * row + 1].v.cn[0] = vtx[4 * row + 2].v.cn[0] = vtx[4 * row + 3].v.cn[0] = 0;
         vtx[4 * row + 0].v.cn[1] = vtx[4 * row + 1].v.cn[1] = vtx[4 * row + 2].v.cn[1] = vtx[4 * row + 3].v.cn[1] = 0;
@@ -234,20 +234,21 @@ Gfx* KaleidoScope_DrawPageSections(Gfx* gfx, Vtx* vertices, TexturePtr* textures
 
     // Draw the rows.
     for (u32 bg_row = 0; bg_row < RECOMP_PAGE_ROW_COUNT; bg_row++) {
+        u32 cur_row_height = MIN(RECOMP_PAGE_ROW_HEIGHT, PAGE_BG_HEIGHT - bg_row * RECOMP_PAGE_ROW_HEIGHT);
         gDPLoadTextureTile(gfx++, *cur_image,
             G_IM_FMT_IA, G_IM_SIZ_8b, // fmt, siz
             PAGE_BG_WIDTH + 2, PAGE_BG_HEIGHT + 2, // width, height
-            0, (bg_row + 0) * RECOMP_PAGE_ROW_HEIGHT, // uls, ult
-            PAGE_BG_WIDTH + 2, (bg_row + 1) * RECOMP_PAGE_ROW_HEIGHT + 2, // lrs, lrt
+            0, bg_row * RECOMP_PAGE_ROW_HEIGHT, // uls, ult
+            PAGE_BG_WIDTH + 2 - 1, bg_row * RECOMP_PAGE_ROW_HEIGHT + cur_row_height + 1 - 1, // lrs, lrt
             0, // pal
-            G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP,
+            G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP,
             G_TX_NOMASK, G_TX_NOMASK,
             G_TX_NOLOD, G_TX_NOLOD);
         gDPSetTileSize(gfx++, G_TX_RENDERTILE,
                 0 << G_TEXTURE_IMAGE_FRAC,
                 0 << G_TEXTURE_IMAGE_FRAC,
-                (PAGE_BG_WIDTH + 2) <<G_TEXTURE_IMAGE_FRAC,
-                (RECOMP_PAGE_ROW_HEIGHT + 2) << G_TEXTURE_IMAGE_FRAC);
+                (PAGE_BG_WIDTH + 2 - 1) <<G_TEXTURE_IMAGE_FRAC,
+                (cur_row_height + 1 - 1) << G_TEXTURE_IMAGE_FRAC);
         gSPVertex(gfx++, vertices + 4 * bg_row, 4, 0);
         gSP2Triangles(gfx++, 0, 3, 1, 0x0, 3, 0, 2, 0x0);
     }

--- a/patches/item_transform_tagging.c
+++ b/patches/item_transform_tagging.c
@@ -2,13 +2,12 @@
 #include "transform_ids.h"
 #include "overlays/actors/ovl_Arms_Hook/z_arms_hook.h"
 
-// TODO replace these with externs when the recompiler can handle relocations in patches automatically.
-Vec3f D_808C1C10 = { 0.0f, 0.0f, 0.0f };
-Vec3f D_808C1C1C = { 0.0f, 0.0f, 900.0f };
-Vec3f D_808C1C28 = { 0.0f, 500.0f, -3000.0f };
-Vec3f D_808C1C34 = { 0.0f, -500.0f, -3000.0f };
-Vec3f D_808C1C40 = { 0.0f, 500.0f, 0.0f };
-Vec3f D_808C1C4C = { 0.0f, -500.0f, 0.0f };
+extern Vec3f D_808C1C10;
+extern Vec3f D_808C1C1C;
+extern Vec3f D_808C1C28;
+extern Vec3f D_808C1C34;
+extern Vec3f D_808C1C40;
+extern Vec3f D_808C1C4C;
 
 extern Gfx object_link_child_DL_01D960[];
 extern Gfx gHookshotChainDL[];
@@ -31,10 +30,7 @@ void ArmsHook_Draw(Actor* thisx, PlayState* play) {
 
         OPEN_DISPS(play->state.gfxCtx);
 
-
-        // @recomp Manually relocate ArmsHook_Shoot because it's an overlay symbol.
-        // TODO remove this when the recompiler handles relocations in patches automatically.
-        if (((ArmsHookActionFunc)actor_relocate(thisx, ArmsHook_Shoot) != this->actionFunc) || (this->timer <= 0)) {
+        if ((ArmsHook_Shoot != this->actionFunc) || (this->timer <= 0)) {
             Matrix_MultVec3f(&D_808C1C10, &this->unk1E0);
             Matrix_MultVec3f(&D_808C1C28, &sp5C);
             Matrix_MultVec3f(&D_808C1C34, &sp50);

--- a/patches/ocarina_effect_patches.c
+++ b/patches/ocarina_effect_patches.c
@@ -1010,14 +1010,12 @@ void set_all_vertex_flags() {
 
 // Patches the given DL to replace a vertex command at the given position with a branch to the new DL.
 void patch_ocarina_effect(Actor* actor, Gfx* original_dl, u32 dl_offset, Gfx* override_dl) {
-    Gfx* reloc_dl = (Gfx*)actor_relocate(actor, original_dl);
-
     set_all_vertex_flags();
 
     // Check if the DL hasn't been patched yet.
-    if (reloc_dl[dl_offset].words.w0 >> 24 == G_VTX) {
+    if (original_dl[dl_offset].words.w0 >> 24 == G_VTX) {
         // Redirect the DL away from the original vertex command and to the override DL.
-        gSPBranchList(&reloc_dl[dl_offset], override_dl);
+        gSPBranchList(&original_dl[dl_offset], override_dl);
     }
 }
 
@@ -1089,8 +1087,7 @@ void OceffWipe_Draw(Actor* thisx, PlayState* play) {
         gDPSetEnvColor(POLY_XLU_DISP++, 100, 0, 255, 128);
     }
 
-    // @recomp Manual relocation, TODO remove when automated.
-    gSPDisplayList(POLY_XLU_DISP++, (Gfx*)actor_relocate(thisx, &sSongOfTimeFrustumMaterialDL));
+    gSPDisplayList(POLY_XLU_DISP++, sSongOfTimeFrustumMaterialDL);
     gSPDisplayList(POLY_XLU_DISP++, Gfx_TwoTexScroll(play->state.gfxCtx, G_TX_RENDERTILE, 0 - scroll, scroll * -2, 32,
                                                      32, 1, 0 - scroll, scroll * -2, 32, 32));
     // @recomp Use the new DL instead of the original.
@@ -1144,8 +1141,7 @@ void OceffWipe2_Draw(Actor* thisx, PlayState* play) {
     gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(play->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
     gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, 255, 255, 170, 255);
     gDPSetEnvColor(POLY_XLU_DISP++, 255, 100, 0, 128);
-    // @recomp Manual relocation, TODO remove when automated.
-    gSPDisplayList(POLY_XLU_DISP++, (Gfx*)actor_relocate(thisx, sEponaSongFrustumMaterialDL));
+    gSPDisplayList(POLY_XLU_DISP++, sEponaSongFrustumMaterialDL);
     gSPDisplayList(POLY_XLU_DISP++, Gfx_TwoTexScroll(play->state.gfxCtx, G_TX_RENDERTILE, scroll * 6, scroll * -6, 64,
                                                      64, 1, scroll * -6, 0, 64, 64));
     // @recomp Use the new DL instead of the original.
@@ -1198,8 +1194,7 @@ void OceffWipe3_Draw(Actor* thisx, PlayState* play) {
     gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(play->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
     gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, 255, 255, 170, 255);
     gDPSetEnvColor(POLY_XLU_DISP++, 100, 200, 0, 128);
-    // @recomp Manual relocation, TODO remove when automated.
-    gSPDisplayList(POLY_XLU_DISP++, (Gfx*)actor_relocate(thisx, &sSariaSongFrustrumMaterialDL));
+    gSPDisplayList(POLY_XLU_DISP++, sSariaSongFrustrumMaterialDL);
     gSPDisplayList(POLY_XLU_DISP++, Gfx_TwoTexScroll(play->state.gfxCtx, 0, scroll * 12, scroll * -12, 64, 64, 1,
                                                      scroll * 8, scroll * -8, 64, 64));
     // @recomp Use the new DL instead of the original.
@@ -1253,17 +1248,16 @@ void OceffWipe4_Draw(Actor* thisx, PlayState* play) {
 
     gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(play->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
-    // @recomp Manual relocations, TODO remove when automated.
     if (this->actor.params == OCEFF_WIPE4_UNUSED) {
-        gSPDisplayList(POLY_XLU_DISP++, (Gfx*)actor_relocate(thisx, sScarecrowSongUnusedMaterialDL));
+        gSPDisplayList(POLY_XLU_DISP++, sScarecrowSongUnusedMaterialDL);
     } else {
-        gSPDisplayList(POLY_XLU_DISP++, (Gfx*)actor_relocate(thisx, sScarecrowSongMaterialDL));
+        gSPDisplayList(POLY_XLU_DISP++, sScarecrowSongMaterialDL);
     }
 
-    gSPDisplayList(POLY_XLU_DISP++, (Gfx*)actor_relocate(thisx, sScarecrowSongModelDL));
+    gSPDisplayList(POLY_XLU_DISP++, sScarecrowSongModelDL);
     gSPDisplayList(POLY_XLU_DISP++, Gfx_TwoTexScroll(play->state.gfxCtx, G_TX_RENDERTILE, scroll * 2, scroll * -2, 32,
                                                      64, 1, scroll * -1, scroll, 32, 32));
-    gSPDisplayList(POLY_XLU_DISP++, (Gfx*)actor_relocate(thisx, &sScarecrowSongModelDL[11]));
+    gSPDisplayList(POLY_XLU_DISP++, &sScarecrowSongModelDL[11]);
 
     CLOSE_DISPS(play->state.gfxCtx);
 }
@@ -1339,9 +1333,8 @@ void OceffWipe5_Draw(Actor* thisx, PlayState* play) {
     gDPSetEnvColor(POLY_XLU_DISP++, sEnvColors[colorIndex], sEnvColors[colorIndex + 1], sEnvColors[colorIndex + 2],
                    255);
 
-    // @recomp Manual relocations, TODO remove when automated.
-    AnimatedMat_Draw(play, (AnimatedMaterial*)actor_relocate(thisx, gOceff5TexAnim));
-    gSPDisplayList(POLY_XLU_DISP++, (Gfx*)actor_relocate(thisx, gOceff5DL));
+    AnimatedMat_Draw(play, gOceff5TexAnim);
+    gSPDisplayList(POLY_XLU_DISP++, gOceff5DL);
 
     CLOSE_DISPS(play->state.gfxCtx);
 }
@@ -1392,9 +1385,8 @@ void OceffWipe6_Draw(Actor* thisx, PlayState* play) {
     Matrix_RotateXS(0x708, MTXMODE_APPLY);
     Matrix_Translate(0.0f, 0.0f, -z, MTXMODE_APPLY);
     gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(play->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
-    // @recomp Manual relocations, TODO remove these when automatic.
-    AnimatedMat_Draw(play, (AnimatedMaterial*)actor_relocate(thisx, ovl_Oceff_Wipe6_Matanimheader_000338));
-    gSPDisplayList(POLY_XLU_DISP++, (Gfx*)actor_relocate(thisx, gOceff6DL));
+    AnimatedMat_Draw(play, ovl_Oceff_Wipe6_Matanimheader_000338);
+    gSPDisplayList(POLY_XLU_DISP++, gOceff6DL);
 
     CLOSE_DISPS(play->state.gfxCtx);
 }
@@ -1443,9 +1435,8 @@ void OceffWipe7_Draw(Actor* thisx, PlayState* play) {
     Matrix_RotateXS(0x708, MTXMODE_APPLY);
     Matrix_Translate(0.0f, 0.0f, -z, MTXMODE_APPLY);
     gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(play->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
-    // @recomp Manual relocations, TODO remove when automated.
-    AnimatedMat_Draw(play, (AnimatedMaterial*)actor_relocate(thisx, sSongofHealingEffectTexAnim));
-    gSPDisplayList(POLY_XLU_DISP++, (Gfx*)actor_relocate(thisx, &sSongOfHealingEffectFrustumDL));
+    AnimatedMat_Draw(play, sSongofHealingEffectTexAnim);
+    gSPDisplayList(POLY_XLU_DISP++, sSongOfHealingEffectFrustumDL);
 
     CLOSE_DISPS(play->state.gfxCtx);
 }

--- a/patches/options.c
+++ b/patches/options.c
@@ -40,63 +40,22 @@ extern u64 gFileSelCopyButtonENGTex[];
 extern u64 gFileSelEraseButtonENGTex[];
 extern u64 gFileSelYesButtonENGTex[];
 extern u64 gFileSelQuitButtonENGTex[];
-
-// TODO extern these when the recompiler handles relocations automatically.
-s16 D_80814280[] = {
-    2, 3, 2, 2, 2, 2, 2, 2, 2, 2, 1, 2, 0, 1, 1, 2, 1, 1, 4, 2, 2, 2, 1, 1, 0, 2, 0, 1, 1, 1, 1, 1, 0,
-    1, 1, 1, 2, 2, 2, 2, 2, 3, 2, 2, 4, 3, 2, 4, 1, 2, 2, 1, 1, 2, 2, 3, 2, 2, 0, 2, 2, 2, 0, 3, 1, 0,
-};
-
-s16 sWindowContentColors[] = { 100, 150, 255 };
-
-TexturePtr sFileInfoBoxTextures[] = {
-    gFileSelFileInfoBox0Tex, gFileSelFileInfoBox1Tex,      gFileSelFileInfoBox2Tex,      gFileSelFileInfoBox3Tex,
-    gFileSelFileInfoBox4Tex, gFileSelFileExtraInfoBox0Tex, gFileSelFileExtraInfoBox1Tex,
-};
-
-TexturePtr sTitleLabels[] = {
-    gFileSelPleaseSelectAFileENGTex, gFileSelOpenThisFileENGTex,    gFileSelCopyWhichFileENGTex,
-    gFileSelCopyToWhichFileENGTex,   gFileSelAreYouSureCopyENGTex,  gFileSelFileCopiedENGTex,
-    gFileSelEraseWhichFileENGTex,    gFileSelAreYouSureEraseENGTex, gFileSelFileErasedENGTex,
-};
-
-TexturePtr sWarningLabels[] = {
-    gFileSelNoFileToCopyENGTex, gFileSelNoFileToEraseENGTex, gFileSelNoEmptyFileENGTex,
-    gFileSelFileEmptyENGTex,    gFileSelFileInUseENGTex,
-};
-
-TexturePtr sFileButtonTextures[] = {
-    gFileSelFile1ButtonENGTex,
-    gFileSelFile2ButtonENGTex,
-    gFileSelFile3ButtonENGTex,
-};
-
-TexturePtr sActionButtonTextures[] = {
-    gFileSelCopyButtonENGTex,
-    gFileSelEraseButtonENGTex,
-    gFileSelYesButtonENGTex,
-    gFileSelQuitButtonENGTex,
-};
-
-s16 sFileInfoBoxPartWidths[] = {
-    36, 36, 36, 36, 24, 28, 28,
-};
-
-s16 sWalletFirstDigit[] = {
-    1, // tens (Default Wallet)
-    0, // hundreds (Adult Wallet)
-    0, // hundreds (Giant Wallet)
-};
-
-s16 D_80814620[] = { 8, 8, 8, 0 };
-s16 D_80814628[] = { 12, 12, 12, 0 };
-s16 D_80814630[] = { 12, 12, 12, 0 };
-s16 D_80814638[] = {
-    88, 104, 120, 940, 944, 948,
-};
-s16 D_80814644[] = { 88, 104, 120, 944 };
-s16 D_8081464C[] = { 940, 944 };
-s16 D_80814650[] = { 940, 944, 948 };
+extern s16 D_80814280[];
+extern s16 sWindowContentColors[];
+extern TexturePtr sFileInfoBoxTextures[];
+extern TexturePtr sTitleLabels[];
+extern TexturePtr sWarningLabels[];
+extern TexturePtr sFileButtonTextures[];
+extern TexturePtr sActionButtonTextures[];
+extern s16 sFileInfoBoxPartWidths[];
+extern s16 sWalletFirstDigit[];
+extern s16 D_80814620[];
+extern s16 D_80814628[];
+extern s16 D_80814630[];
+extern s16 D_80814638[];
+extern s16 D_80814644[];
+extern s16 D_8081464C[];
+extern s16 D_80814650[];
 
 void FileSelect_Main(GameState* thisx);
 void FileSelect_InitContext(GameState* thisx);
@@ -118,10 +77,8 @@ void FileSelect_Init(GameState* thisx) {
     ShrinkWindow_Init();
     View_Init(&this->view, this->state.gfxCtx);
 
-    // @recomp manually relocate these symbols as the recompiler doesn't do this automatically for patches yet.
-    GameStateOverlay* ovl = &gGameStateOverlayTable[GAMESTATE_FILE_SELECT];
-    this->state.main = (void*)((u32)FileSelect_Main - (u32)ovl->vramStart + (u32)ovl->loadedRamAddr);
-    this->state.destroy = (void*)((u32)FileSelect_Destroy - (u32)ovl->vramStart + (u32)ovl->loadedRamAddr);
+    this->state.main = FileSelect_Main;
+    this->state.destroy = FileSelect_Destroy;
 
     FileSelect_InitContext(&this->state);
     Font_LoadOrderedFont(&this->font);

--- a/patches/particle_transform_tagging.c
+++ b/patches/particle_transform_tagging.c
@@ -381,7 +381,6 @@ void DemoKankyo_DrawMoonAndGiant(Actor* thisx, PlayState* play2) {
 }
 
 static Vec3f D_80A5AFB0 = { 0.0f, 0.0f, 0.0f };
-static Vec3f D_80A5AFBC = { 0.0f, -1.0f, 0.0f };
 
 // The byte after unk_01 in EnWaterEffectStruct is unused, so we'll use it as a respawn flag.
 #define WATER_EFFECT_RESPAWNED(ptr) (&(ptr)->unk_01)[1]

--- a/patches/particle_transform_tagging.c
+++ b/patches/particle_transform_tagging.c
@@ -101,7 +101,7 @@ extern Gfx gSunSparkleModelDL[];
 extern u8 D_80B23C40[];
 extern u8 D_80B23C2C[];
 
-// @recomp Modified to take the actor as an argument for relocation and to tag firework transforms.
+// @recomp Modified to tag firework transforms.
 void func_80B22FA8_patched(Actor* thisx, EnHanabiStruct* arg0, PlayState* play2) {
     PlayState* play = play2;
     GraphicsContext* gfxCtx = play->state.gfxCtx;
@@ -118,10 +118,6 @@ void func_80B22FA8_patched(Actor* thisx, EnHanabiStruct* arg0, PlayState* play2)
     gSPDisplayList(POLY_XLU_DISP++, gSunSparkleMaterialDL);
 
     sp53 = 0xFF;
-
-    // @recomp Manually relocate, TODO remove when automated by recompiler.
-    u8* D_80B23C40_relocated = (u8*)actor_relocate(thisx, D_80B23C40);
-    u8* D_80B23C2C_relocated = (u8*)actor_relocate(thisx, D_80B23C2C);
 
     for (i = 0; i < 400; i++, arg0++) {
         if (arg0->unk_00 != 1) {
@@ -145,18 +141,18 @@ void func_80B22FA8_patched(Actor* thisx, EnHanabiStruct* arg0, PlayState* play2)
 
         if (sp53 != arg0->unk_02) {
             gDPPipeSync(POLY_XLU_DISP++);
-            gDPSetEnvColor(POLY_XLU_DISP++, D_80B23C40_relocated[arg0->unk_02], D_80B23C40_relocated[arg0->unk_02 + 1],
-                           D_80B23C40_relocated[arg0->unk_02 + 2], 255);
+            gDPSetEnvColor(POLY_XLU_DISP++, D_80B23C40[arg0->unk_02], D_80B23C40[arg0->unk_02 + 1],
+                           D_80B23C40[arg0->unk_02 + 2], 255);
 
             sp53 = arg0->unk_02;
         }
 
         if (arg0->unk_01 < 6) {
-            gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, D_80B23C2C_relocated[arg0->unk_02], D_80B23C2C_relocated[arg0->unk_02 + 1],
-                            D_80B23C2C_relocated[arg0->unk_02 + 2], arg0->unk_01 * 50);
+            gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, D_80B23C2C[arg0->unk_02], D_80B23C2C[arg0->unk_02 + 1],
+                            D_80B23C2C[arg0->unk_02 + 2], arg0->unk_01 * 50);
         } else {
-            gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, D_80B23C2C_relocated[arg0->unk_02], D_80B23C2C_relocated[arg0->unk_02 + 1],
-                            D_80B23C2C_relocated[arg0->unk_02 + 2], 255);
+            gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, D_80B23C2C[arg0->unk_02], D_80B23C2C[arg0->unk_02 + 1],
+                            D_80B23C2C[arg0->unk_02 + 2], 255);
         }
 
         gSPDisplayList(POLY_XLU_DISP++, gSunSparkleModelDL);
@@ -172,7 +168,7 @@ void EnHanabi_Draw(Actor* thisx, PlayState* play) {
     EnHanabi* this = (EnHanabi*)thisx;
 
     Matrix_Push();
-    // @recomp Call a modified version of the function that takes the actor for relocation purposes.
+    // @recomp Call a modified version of the function that takes the actor for tagging purposes.
     func_80B22FA8_patched(thisx, this->unk_148, play);
     Matrix_Pop();
 }

--- a/patches/patches.h
+++ b/patches/patches.h
@@ -63,17 +63,6 @@
 int recomp_printf(const char* fmt, ...);
 float recomp_powf(float, float);
 
-static inline void* actor_relocate(Actor* actor, void* addr) {
-    if ((uintptr_t)addr >= 0x80800000) {
-        return (void*)((uintptr_t)addr -
-                (intptr_t)((uintptr_t)actor->overlayEntry->vramStart - (uintptr_t)actor->overlayEntry->loadedRamAddr));
-    }
-    else {
-        recomp_printf("Not an overlay address!: 0x%08X 0x%08X 0x%08X\n", (u32)addr, (u32)actor->overlayEntry->vramStart, (u32)actor->overlayEntry->loadedRamAddr);
-        return addr;
-    }
-}
-
 typedef enum {
     /* 0 */ PICTO_BOX_STATE_OFF,         // Not using the pictograph
     /* 1 */ PICTO_BOX_STATE_LENS,        // Looking through the lens of the pictograph

--- a/patches/patches.ld
+++ b/patches/patches.ld
@@ -20,6 +20,7 @@ SECTIONS {
     .pad           : { . += 0x1000000;            } >extram AT >rom
     .text          : { *(.text*)                  } >extram AT >rom
     
+    .reloc 0 : { *(.reloc*) }
     .symtab 0 : { *(.symtab) }
     .strtab 0 : { *(.strtab) }
     .shstrtab 0 : { *(.shstrtab) }

--- a/patches/patches.ld
+++ b/patches/patches.ld
@@ -9,16 +9,11 @@ MEMORY {
 SECTIONS {
     .ctors         : { *(.ctors*) *(.init_array*) } >extram AT >rom
     .dtors         : { *(.dtors*)                 } >extram AT >rom
+    .text          : { *(.text*)                  } >extram AT >rom
     .rodata        : { *(.rodata*)                } >extram AT >rom
     .data          : { *(.data*)                  } >extram AT >rom
-    
-    /* The following sections will be removed from the objcopy */
-    /* bss isn't noload to make .text rom addresses valid for the recompiler */
-    .bss           : { *(.bss*)  *(COMMON)        } >extram AT >rom
+    .bss  (NOLOAD) : { *(.bss*)  *(COMMON)        } >extram
     ASSERT(. < RAMBASE + EXTRA_RAM_SIZE, "Maxed out recomp extra ram")
-    /* Padding to push .text to avoid conflicts with original function addresses */
-    .pad           : { . += 0x1000000;            } >extram AT >rom
-    .text          : { *(.text*)                  } >extram AT >rom
     
     .reloc 0 : { *(.reloc*) }
     .symtab 0 : { *(.symtab) }

--- a/patches/song_transform_tagging.c
+++ b/patches/song_transform_tagging.c
@@ -29,14 +29,10 @@ void EnTest7_Draw(Actor* thisx, PlayState* play) {
         if (mtx == NULL) {
             return;
         }
-        // func_80AF31D0 is an overlay symbol, so its addresses need to be offset to get the actual loaded vram address.
-        // TODO remove this once the recompiler is able to handle overlay symbols automatically for patch functions.
-        OverrideKeyframeDrawScaled func_80AF31D0_relocated = (OverrideKeyframeDrawScaled)actor_relocate(thisx, func_80AF31D0);
-        
         // @recomp Push the matrix group for the song of soaring's wings.
         gEXMatrixGroupDecomposedNormal(POLY_OPA_DISP++, SOARING_WINGS_TRANSFORM_ID, G_EX_PUSH, G_MTX_MODELVIEW, G_EX_EDIT_ALLOW);
         
-        func_8018450C(play, &this->skeletonInfo, mtx, func_80AF31D0_relocated, NULL, &this->actor);
+        func_8018450C(play, &this->skeletonInfo, mtx, func_80AF31D0, NULL, &this->actor);
         
         // @recomp Pop the wings matrix group.
         gEXPopMatrixGroup(POLY_OPA_DISP++, G_MTX_MODELVIEW);
@@ -180,12 +176,9 @@ void EnTest6_DrawThreeDayResetSoTCutscene(EnTest6* this, PlayState* play) {
 
     POLY_OPA_DISP = this->gfx;
 
-    // @recomp Manual relocation, TODO remove when automated.
-    SoTCsAmmoDrops* sSoTCsAmmoDrops_reloc = (SoTCsAmmoDrops*)actor_relocate(&this->actor, sSoTCsAmmoDrops);
-
     for (i = 0; i < ARRAY_COUNT(sSoTCsAmmoDrops); i++) {
-        if (sSoTCsAmmoDrops_reloc[i].scale > 0.0f) {
-            sSoTCsAmmoDrops_reloc[i].draw(this, play, &sSoTCsAmmoDrops_reloc[i]);
+        if (sSoTCsAmmoDrops[i].scale > 0.0f) {
+            sSoTCsAmmoDrops[i].draw(this, play, &sSoTCsAmmoDrops[i]);
         }
     }
 

--- a/patches/specific_actor_transform_tagging.c
+++ b/patches/specific_actor_transform_tagging.c
@@ -46,17 +46,14 @@ void EnTanron2_Draw(Actor* thisx, PlayState* play2) {
 
     tanron2 = play->actorCtx.actorLists[ACTORCAT_BOSS].first;
 
-    // @recomp Manual relocation, TODO remove this when the recompiler does it automatically.
-    EnTanron2** D_80BB8458_relocated = (EnTanron2**)actor_relocate(thisx, D_80BB8458);
-
     for (i = 0; i < ARRAY_COUNT(D_80BB8458); i++) {
-        D_80BB8458_relocated[i] = NULL;
+        D_80BB8458[i] = NULL;
     }
 
     found = 0;
     while (tanron2 != NULL) {
         if (tanron2->params < 100) {
-            D_80BB8458_relocated[found] = (EnTanron2*)tanron2;
+            D_80BB8458[found] = (EnTanron2*)tanron2;
             found++;
         }
         tanron2 = tanron2->next;
@@ -64,26 +61,26 @@ void EnTanron2_Draw(Actor* thisx, PlayState* play2) {
 
     for (j = 0; j < found - 1; j++) {
         for (i = 0; i < found - 1; i++) {
-            if (D_80BB8458_relocated[i + 1] != NULL) {
-                if (D_80BB8458_relocated[i]->actor.projectedPos.z < D_80BB8458_relocated[i + 1]->actor.projectedPos.z) {
-                    SWAP(EnTanron2*, D_80BB8458_relocated[i], D_80BB8458_relocated[i + 1]);
+            if (D_80BB8458[i + 1] != NULL) {
+                if (D_80BB8458[i]->actor.projectedPos.z < D_80BB8458[i + 1]->actor.projectedPos.z) {
+                    SWAP(EnTanron2*, D_80BB8458[i], D_80BB8458[i + 1]);
                 }
             }
         }
     }
 
     for (i = 0; i < ARRAY_COUNT(D_80BB8458); i++) {
-        if (D_80BB8458_relocated[i] != NULL) {
-            Matrix_Translate(D_80BB8458_relocated[i]->actor.world.pos.x, D_80BB8458_relocated[i]->actor.world.pos.y,
-                             D_80BB8458_relocated[i]->actor.world.pos.z, MTXMODE_NEW);
+        if (D_80BB8458[i] != NULL) {
+            Matrix_Translate(D_80BB8458[i]->actor.world.pos.x, D_80BB8458[i]->actor.world.pos.y,
+                             D_80BB8458[i]->actor.world.pos.z, MTXMODE_NEW);
             Matrix_ReplaceRotation(&play->billboardMtxF);
-            Matrix_Scale(D_80BB8458_relocated[i]->actor.scale.x, D_80BB8458_relocated[i]->actor.scale.y, 0.0f, MTXMODE_APPLY);
-            Matrix_RotateZS(D_80BB8458_relocated[i]->unk_14A, MTXMODE_APPLY);
+            Matrix_Scale(D_80BB8458[i]->actor.scale.x, D_80BB8458[i]->actor.scale.y, 0.0f, MTXMODE_APPLY);
+            Matrix_RotateZS(D_80BB8458[i]->unk_14A, MTXMODE_APPLY);
             Matrix_Scale(0.13f, 0.14299999f, 0.13f, MTXMODE_APPLY);
-            Matrix_RotateZS(-D_80BB8458_relocated[i]->unk_14A, MTXMODE_APPLY);
+            Matrix_RotateZS(-D_80BB8458[i]->unk_14A, MTXMODE_APPLY);
 
             // @recomp Tag the transform.
-            gEXMatrixGroupSimple(POLY_XLU_DISP++, actor_transform_id(&D_80BB8458_relocated[i]->actor) + 0,
+            gEXMatrixGroupSimple(POLY_XLU_DISP++, actor_transform_id(&D_80BB8458[i]->actor) + 0,
                 G_EX_PUSH, G_MTX_MODELVIEW,
                 G_EX_COMPONENT_INTERPOLATE, G_EX_COMPONENT_INTERPOLATE, G_EX_COMPONENT_INTERPOLATE, G_EX_COMPONENT_INTERPOLATE,
                 G_EX_COMPONENT_INTERPOLATE, G_EX_ORDER_LINEAR, G_EX_EDIT_NONE);
@@ -100,14 +97,11 @@ void EnTanron2_Draw(Actor* thisx, PlayState* play2) {
 
     gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, 0, 0, 0, 150);
     gSPDisplayList(POLY_XLU_DISP++, gWartShadowMaterialDL);
-    
-    // @recomp Manual relocation, TODO remove this when the recompiler does it automatically.
-    Boss04** D_80BB8450_relocated = (Boss04**)actor_relocate(thisx, &D_80BB8450);
 
     tanron2 = play->actorCtx.actorLists[ACTORCAT_BOSS].first;
     while (tanron2 != NULL) {
         if ((tanron2->params < 100) && (((EnTanron2*)tanron2)->unk_15B != 0)) {
-            Matrix_Translate(tanron2->world.pos.x, (*D_80BB8450_relocated)->actor.floorHeight, tanron2->world.pos.z, MTXMODE_NEW);
+            Matrix_Translate(tanron2->world.pos.x, D_80BB8450->actor.floorHeight, tanron2->world.pos.z, MTXMODE_NEW);
             Matrix_Scale(0.6f, 0.0f, 0.6f, MTXMODE_APPLY);
 
             // @recomp Tag the transform.
@@ -136,12 +130,9 @@ void EnTanron2_Draw(Actor* thisx, PlayState* play2) {
     while (tanron2 != NULL) {
         if ((tanron2->params < 100) && (((EnTanron2*)tanron2)->unk_15B != 0) &&
             (tanron2->world.pos.y <= tanron2->floorHeight)) {
-            Matrix_Translate(tanron2->world.pos.x, (*D_80BB8450_relocated)->actor.floorHeight + 2.0f, tanron2->world.pos.z,
+            Matrix_Translate(tanron2->world.pos.x, D_80BB8450->actor.floorHeight + 2.0f, tanron2->world.pos.z,
                              MTXMODE_NEW);
-                             
-            // @recomp Manual relocation, TODO remove this when the recompiler does it automatically.
-            f32 D_80BB8454_value = *(f32*)actor_relocate(thisx, &D_80BB8454);
-            Matrix_Scale(D_80BB8454_value, 0.0f, D_80BB8454_value, MTXMODE_APPLY);
+            Matrix_Scale(D_80BB8454, 0.0f, D_80BB8454, MTXMODE_APPLY);
 
             // @recomp Tag the transform.
             gEXMatrixGroupSimple(POLY_XLU_DISP++, actor_transform_id(tanron2) + 2,
@@ -732,20 +723,15 @@ void EnOsn_Idle(EnOsn* this, PlayState* play);
 
 // @recomp Patched to skip interpolation when the Happy Mask Salesman changes animations.
 void EnOsn_ChooseAction(EnOsn* this, PlayState* play) {
-    // @recomp Manually relocate the static symbol.
-    AnimationInfo* sAnimationInfo = (AnimationInfo*)actor_relocate(&this->actor, sHappyMaskSalesmanAnimationInfo);
-
     u32 isSwitchFlagSet = Flags_GetSwitch(play, 0);
 
     this->csId = this->actor.csId;
 
-    Actor_ChangeAnimationByInfo(&this->skelAnime, sAnimationInfo, OSN_ANIM_IDLE);
+    Actor_ChangeAnimationByInfo(&this->skelAnime, sHappyMaskSalesmanAnimationInfo, OSN_ANIM_IDLE);
     if (!isSwitchFlagSet) {
-        // @recomp No need to relocate as this function is replaced, so the patch compilation will pick the new address.
         this->actionFunc = EnOsn_HandleCsAction;
     } else {
-        // @recomp Manual relocation, TODO remove when automated by the recompiler.
-        this->actionFunc = (EnOsnActionFunc)actor_relocate(&this->actor, EnOsn_Idle);
+        this->actionFunc = EnOsn_Idle;
     }
     
     // @recomp Skip interpolation this frame.
@@ -854,11 +840,8 @@ void EnOsn_HandleCsAction(EnOsn* this, PlayState* play) {
                 default:
                     this->animIndex = OSN_ANIM_IDLE;
                     break;
-            }
-            // @recomp Manually relocate the static symbol.
-            AnimationInfo* sAnimationInfo = (AnimationInfo*)actor_relocate(&this->actor, sHappyMaskSalesmanAnimationInfo);
-            
-            Actor_ChangeAnimationByInfo(&this->skelAnime, sAnimationInfo, this->animIndex);
+            }            
+            Actor_ChangeAnimationByInfo(&this->skelAnime, sHappyMaskSalesmanAnimationInfo, this->animIndex);
 
             // @recomp Skip interpolation this frame.
             actor_set_interpolation_skipped(&this->actor);
@@ -981,10 +964,8 @@ void func_80A34B28(ObjEntotu* this, PlayState* play) {
 
     this->unk_1B8.x = CLAMP(this->unk_1B8.x, 0.0f, 1.0f);
 
-    // @recomp Manual relocation, TODO remove when automated.
-    Vtx* verts = (Vtx*)actor_relocate(&this->actor, ovl_Obj_Entotu_Vtx_000D10);
     for (i = 0; i < ARRAY_COUNT(ovl_Obj_Entotu_Vtx_000D10); i++) {
-        this->unk_148[i].v.cn[3] = verts[i].v.cn[3] * this->unk_1B8.x;
+        this->unk_148[i].v.cn[3] = ovl_Obj_Entotu_Vtx_000D10[i].v.cn[3] * this->unk_1B8.x;
     }
 
     if (this->unk_1B8.x > 0.0f) {

--- a/patches/syms.ld
+++ b/patches/syms.ld
@@ -1,21 +1,5 @@
 __start = 0x80000000;
 
-/* Manual symbol overrides to work around recompiler ambiguity issue (TODO fix this) */
-_ovl_daytelopSegmentOvlEnd = 0x0;
-_ovl_kaleido_scopeSegmentTextStart = 0x0;
-_ovl_kaleido_scopeSegmentStart = 0x0;
-_ovl_daytelopSegmentBssStart = 0x0;
-_ovl_daytelopSegmentEnd = 0x0;
-_ovl_daytelopSegmentBssEnd = 0x0;
-
-/* Static symbols that aren't in the elf */
-sSceneEntranceTable = 0x801C5720;
-D_808DE5B0 = 0x808DE5B0;
-sHappyMaskSalesmanAnimationInfo = 0x80AD22C0;
-D_808890F0 = 0x808890F0;
-D_8088911C = 0x8088911C;
-D_809EE4D0 = 0x809EE4D0;
-
 /* Dummy addresses that get recompiled into function calls */
 recomp_puts = 0x8F000000;
 recomp_exit = 0x8F000004;

--- a/patches/terrain_transform_tagging.c
+++ b/patches/terrain_transform_tagging.c
@@ -162,8 +162,7 @@ void DmChar01_Draw(Actor* thisx, PlayState* play) {
                         gDPPipeSync(POLY_OPA_DISP++);
                         gDPSetEnvColor(POLY_OPA_DISP++, 0, 0, 0, 255);
                         gDPSetPrimColor(POLY_OPA_DISP++, 0, 0x96, 255, 255, 255, 255);
-                        // @recomp Manual relocation, TODO remove when automated.
-                        gSPSegment(POLY_OPA_DISP++, 0x0B, actor_relocate(thisx, gWoodfallSceneryDynamicPoisonWaterVtx));
+                        gSPSegment(POLY_OPA_DISP++, 0x0B, gWoodfallSceneryDynamicPoisonWaterVtx);
                         gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(play->state.gfxCtx),
                                   G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
                         // @recomp Tag the matrix to enable vertex interpolation.
@@ -178,8 +177,7 @@ void DmChar01_Draw(Actor* thisx, PlayState* play) {
                         gDPPipeSync(POLY_XLU_DISP++);
                         gDPSetEnvColor(POLY_XLU_DISP++, 0, 0, 0, (u8)this->unk_348);
                         gDPSetPrimColor(POLY_XLU_DISP++, 0, 0x96, 255, 255, 255, (u8)this->unk_348);
-                        // @recomp Manual relocation, TODO remove when automated.
-                        gSPSegment(POLY_XLU_DISP++, 0x0B, actor_relocate(thisx, gWoodfallSceneryDynamicPoisonWaterVtx));
+                        gSPSegment(POLY_XLU_DISP++, 0x0B, gWoodfallSceneryDynamicPoisonWaterVtx);
                         gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(play->state.gfxCtx),
                                   G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
                         // @recomp Tag the matrix to enable vertex interpolation.
@@ -235,21 +233,16 @@ void DmChar01_Draw(Actor* thisx, PlayState* play) {
                 CLOSE_DISPS(play->state.gfxCtx);
             }
             
-            // @recomp Manual relocations, TODO remove when automated.
-            s16 D_80AAAE20_val = *(s16*)actor_relocate(thisx, &D_80AAAE20);
-            s16 D_80AAAE22_val = *(s16*)actor_relocate(thisx, &D_80AAAE22);
-            s16 D_80AAAE24_val = *(s16*)actor_relocate(thisx, &D_80AAAE24);
-
-            if (D_80AAAE24_val != 0) {
-                if ((D_80AAAE22_val > -1800) && (D_80AAAE22_val < 3000)) {
-                    temp_f12 = D_80AAAE22_val - 640.0f;
-                    if ((D_80AAAE20_val == 380) && (D_80AAAE22_val > 640)) {
+            if (D_80AAAE24 != 0) {
+                if ((D_80AAAE22 > -1800) && (D_80AAAE22 < 3000)) {
+                    temp_f12 = D_80AAAE22 - 640.0f;
+                    if ((D_80AAAE20 == 380) && (D_80AAAE22 > 640)) {
                         D_80AAAAC0 = 2;
                         D_80AAAAC4 = 0;
                         D_80AAAAC8 = 900;
                         D_80AAAACC = 700;
                         spB7 = true;
-                        if (D_80AAAE22_val < 1350) {
+                        if (D_80AAAE22 < 1350) {
                             f32 temp_f0 = temp_f12 / 2000.0f;
 
                             D_80AAAAB8 = 420.0f - (420.0f * temp_f0);

--- a/patches/terrain_transform_tagging.c
+++ b/patches/terrain_transform_tagging.c
@@ -122,14 +122,16 @@ extern s16 D_80AAAE20;
 extern s16 D_80AAAE22;
 extern s16 D_80AAAE24;
 
+extern f32 D_80AAAAB8;
+extern f32 D_80AAAABC;
+extern s16 D_80AAAAC0;
+extern s16 D_80AAAAC4;
+extern s16 D_80AAAAC8;
+extern s16 D_80AAAACC;
+
 // @recomp Patched to enable vertex interpolation for the dynamic water as Woodfall temple rises from below the water.
 void DmChar01_Draw(Actor* thisx, PlayState* play) {
-    static f32 D_80AAAAB8 = 0.0f;
-    static f32 D_80AAAABC = 0.0f;
-    static s16 D_80AAAAC0 = 0;
-    static s16 D_80AAAAC4 = 0;
-    static s16 D_80AAAAC8 = 0;
-    static s16 D_80AAAACC = 0;
+    // @recomp Move function statics to externs so they still get reset on overlay load like normal.
     DmChar01* this = (DmChar01*)thisx;
     f32 temp_f12;
     f32 spBC;

--- a/patches/ui_patches.c
+++ b/patches/ui_patches.c
@@ -540,10 +540,10 @@ void Interface_Draw(PlayState* play) {
             extern s16 sMaskEquipAnimTimer;
             extern s16 sEquipState;
             extern s16 sMaskEquipState;
-            s16 equip_timer =      *(s16*)KaleidoManager_GetRamAddr(&sEquipAnimTimer);
-            s16 mask_equip_timer = *(s16*)KaleidoManager_GetRamAddr(&sMaskEquipAnimTimer);
-            s16 equip_state =      *(s16*)KaleidoManager_GetRamAddr(&sEquipState);
-            s16 mask_equip_state = *(s16*)KaleidoManager_GetRamAddr(&sMaskEquipState);
+            s16 equip_timer =      sEquipAnimTimer;
+            s16 mask_equip_timer = sMaskEquipAnimTimer;
+            s16 equip_state =      sEquipState;
+            s16 mask_equip_state = sMaskEquipState;
 
             s16 timer = MIN(equip_timer, mask_equip_timer);
             s32 max_timer = 10;

--- a/patches/ui_transform_tagging.c
+++ b/patches/ui_transform_tagging.c
@@ -54,14 +54,6 @@ extern TexturePtr sMapPageBgTextures[];
 extern TexturePtr sQuestPageBgTextures[];
 extern TexturePtr sMaskPageBgTextures[];
 
-s16 kaleido_s16(s16* addr) {
-    return *(s16*)KaleidoManager_GetRamAddr(addr);
-}
-
-f32 kaleido_f32(f32* addr) {
-    return *(f32*)KaleidoManager_GetRamAddr(addr);
-}
-
 // @recomp Patched to set pageIndex to a dummy value when KaleidoScope_SetVertices is called to make it
 // allocate vertices for all pages at all times. This is simpler than patching KaleidoScope_SetVertices directly.
 void KaleidoScope_Draw(PlayState* play) {
@@ -164,9 +156,8 @@ void KaleidoScope_DrawCursor(PlayState* play) {
         gDPSetCombineLERP(POLY_OPA_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0,
                           PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
 
-        // @recomp manual relocations, TODO remove when recompiler can handle this.
-        gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, kaleido_s16(&sCursorPrimR), kaleido_s16(&sCursorPrimG), kaleido_s16(&sCursorPrimB), 255);
-        gDPSetEnvColor(POLY_OPA_DISP++, kaleido_s16(&sCursorEnvR), kaleido_s16(&sCursorEnvG), kaleido_s16(&sCursorEnvB), 255);
+        gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, sCursorPrimR, sCursorPrimG, sCursorPrimB, 255);
+        gDPSetEnvColor(POLY_OPA_DISP++, sCursorEnvR, sCursorEnvG, sCursorEnvB, 255);
 
         Matrix_Translate(pauseCtx->cursorX, pauseCtx->cursorY, -50.0f, MTXMODE_NEW);
         Matrix_Scale(1.0f, 1.0f, 1.0f, MTXMODE_APPLY);
@@ -181,8 +172,7 @@ void KaleidoScope_DrawCursor(PlayState* play) {
 
         for (i = 0; i < 4; i++) {
             Matrix_Push();
-            // @recomp manual relocations, TODO remove when recompiler can handle this.
-            Matrix_Translate(kaleido_f32(&sCursorCirclesX[i]), kaleido_f32(&sCursorCirclesY[i]), -50.0f, MTXMODE_APPLY);
+            Matrix_Translate(sCursorCirclesX[i], sCursorCirclesY[i], -50.0f, MTXMODE_APPLY);
 
             gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(play->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
             gDPPipeSync(POLY_OPA_DISP++);
@@ -242,11 +232,6 @@ void KaleidoScope_DrawInfoPanel(PlayState* play) {
     s16 i;
     s16 j;
 
-    // @recomp Manual relocations, TODO remove when done automatically by the recompiler.
-    s16* sPauseZRCursorColorTimerInits_reloc = KaleidoManager_GetRamAddr(&sPauseZRCursorColorTimerInits);
-    TexturePtr* D_8082B998_reloc = KaleidoManager_GetRamAddr(&D_8082B998);
-    TexturePtr* D_8082B9A8_reloc = KaleidoManager_GetRamAddr(&D_8082B9A8);
-
     OPEN_DISPS(play->state.gfxCtx);
 
     stepR =
@@ -288,7 +273,7 @@ void KaleidoScope_DrawInfoPanel(PlayState* play) {
         sPauseZRCursorGreen = sPauseZRCursorColorTargets[sPauseZRCursorColorIndex][1];
         sPauseZRCursorBlue = sPauseZRCursorColorTargets[sPauseZRCursorColorIndex][2];
         sPauseZRCursorAlpha = sPauseZRCursorColorTargets[sPauseZRCursorColorIndex][3];
-        sPauseZRCursorColorTimer = sPauseZRCursorColorTimerInits_reloc[0];
+        sPauseZRCursorColorTimer = sPauseZRCursorColorTimerInits[0];
         sPauseZRCursorColorIndex ^= 1;
     }
 
@@ -331,42 +316,42 @@ void KaleidoScope_DrawInfoPanel(PlayState* play) {
     pauseCtx->infoPanelVtx[5].v.ob[0] = pauseCtx->infoPanelVtx[7].v.ob[0] = pauseCtx->infoPanelVtx[4].v.ob[0] + 72;
 
     if ((pauseCtx->cursorSpecialPos == PAUSE_CURSOR_PAGE_LEFT) && (pauseCtx->mainState == PAUSE_MAIN_STATE_IDLE)) {
-        pauseCtx->infoPanelVtx[8].v.ob[0] = pauseCtx->infoPanelVtx[10].v.ob[0] = kaleido_s16(&sPauseCursorLeftX);
+        pauseCtx->infoPanelVtx[8].v.ob[0] = pauseCtx->infoPanelVtx[10].v.ob[0] = sPauseCursorLeftX;
 
         pauseCtx->infoPanelVtx[9].v.ob[0] = pauseCtx->infoPanelVtx[11].v.ob[0] = pauseCtx->infoPanelVtx[8].v.ob[0] + 24;
 
-        pauseCtx->infoPanelVtx[8].v.ob[1] = pauseCtx->infoPanelVtx[9].v.ob[1] = kaleido_s16(&D_8082B920);
+        pauseCtx->infoPanelVtx[8].v.ob[1] = pauseCtx->infoPanelVtx[9].v.ob[1] = D_8082B920;
 
         pauseCtx->infoPanelVtx[10].v.ob[1] = pauseCtx->infoPanelVtx[11].v.ob[1] =
             pauseCtx->infoPanelVtx[8].v.ob[1] - 32;
     } else {
-        pauseCtx->infoPanelVtx[8].v.ob[0] = pauseCtx->infoPanelVtx[10].v.ob[0] = kaleido_s16(&sPauseCursorLeftX) + 3;
+        pauseCtx->infoPanelVtx[8].v.ob[0] = pauseCtx->infoPanelVtx[10].v.ob[0] = sPauseCursorLeftX + 3;
 
         pauseCtx->infoPanelVtx[9].v.ob[0] = pauseCtx->infoPanelVtx[11].v.ob[0] = pauseCtx->infoPanelVtx[8].v.ob[0] + 18;
 
-        pauseCtx->infoPanelVtx[8].v.ob[1] = pauseCtx->infoPanelVtx[9].v.ob[1] = kaleido_s16(&D_8082B920) - 3;
+        pauseCtx->infoPanelVtx[8].v.ob[1] = pauseCtx->infoPanelVtx[9].v.ob[1] = D_8082B920 - 3;
 
         pauseCtx->infoPanelVtx[10].v.ob[1] = pauseCtx->infoPanelVtx[11].v.ob[1] =
             pauseCtx->infoPanelVtx[8].v.ob[1] - 26;
     }
 
     if ((pauseCtx->cursorSpecialPos == PAUSE_CURSOR_PAGE_RIGHT) && (pauseCtx->mainState == PAUSE_MAIN_STATE_IDLE)) {
-        pauseCtx->infoPanelVtx[12].v.ob[0] = pauseCtx->infoPanelVtx[14].v.ob[0] = kaleido_s16(&sPauseCursorRightX);
+        pauseCtx->infoPanelVtx[12].v.ob[0] = pauseCtx->infoPanelVtx[14].v.ob[0] = sPauseCursorRightX;
 
         pauseCtx->infoPanelVtx[13].v.ob[0] = pauseCtx->infoPanelVtx[15].v.ob[0] =
             pauseCtx->infoPanelVtx[12].v.ob[0] + 24;
 
-        pauseCtx->infoPanelVtx[12].v.ob[1] = pauseCtx->infoPanelVtx[13].v.ob[1] = kaleido_s16(&D_8082B920);
+        pauseCtx->infoPanelVtx[12].v.ob[1] = pauseCtx->infoPanelVtx[13].v.ob[1] = D_8082B920;
 
         pauseCtx->infoPanelVtx[14].v.ob[1] = pauseCtx->infoPanelVtx[15].v.ob[1] =
             pauseCtx->infoPanelVtx[12].v.ob[1] - 32;
     } else {
-        pauseCtx->infoPanelVtx[12].v.ob[0] = pauseCtx->infoPanelVtx[14].v.ob[0] = kaleido_s16(&sPauseCursorRightX) + 3;
+        pauseCtx->infoPanelVtx[12].v.ob[0] = pauseCtx->infoPanelVtx[14].v.ob[0] = sPauseCursorRightX + 3;
 
         pauseCtx->infoPanelVtx[13].v.ob[0] = pauseCtx->infoPanelVtx[15].v.ob[0] =
             pauseCtx->infoPanelVtx[12].v.ob[0] + 18;
 
-        pauseCtx->infoPanelVtx[12].v.ob[1] = pauseCtx->infoPanelVtx[13].v.ob[1] = kaleido_s16(&D_8082B920) - 3;
+        pauseCtx->infoPanelVtx[12].v.ob[1] = pauseCtx->infoPanelVtx[13].v.ob[1] = D_8082B920 - 3;
 
         pauseCtx->infoPanelVtx[14].v.ob[1] = pauseCtx->infoPanelVtx[15].v.ob[1] =
             pauseCtx->infoPanelVtx[12].v.ob[1] - 26;
@@ -512,10 +497,10 @@ void KaleidoScope_DrawInfoPanel(PlayState* play) {
 
                 if (pauseCtx->cursorSpecialPos == PAUSE_CURSOR_PAGE_LEFT) {
                     POLY_OPA_DISP =
-                        Gfx_DrawTexQuad4b(POLY_OPA_DISP, D_8082B998_reloc[pauseCtx->pageIndex], G_IM_FMT_IA, 128, 16, 0);
+                        Gfx_DrawTexQuad4b(POLY_OPA_DISP, D_8082B998[pauseCtx->pageIndex], G_IM_FMT_IA, 128, 16, 0);
                 } else {
                     POLY_OPA_DISP =
-                        Gfx_DrawTexQuad4b(POLY_OPA_DISP, D_8082B9A8_reloc[pauseCtx->pageIndex], G_IM_FMT_IA, 128, 16, 0);
+                        Gfx_DrawTexQuad4b(POLY_OPA_DISP, D_8082B9A8[pauseCtx->pageIndex], G_IM_FMT_IA, 128, 16, 0);
                 }
             }
         } else if ((!pauseCtx->pageIndex || (pauseCtx->pageIndex == PAUSE_MASK)) &&
@@ -541,7 +526,7 @@ void KaleidoScope_DrawInfoPanel(PlayState* play) {
             gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 255, 255, 255, 255);
 
             POLY_OPA_DISP = Gfx_DrawTexQuad4b(POLY_OPA_DISP, gPauseToEquipENGTex, G_IM_FMT_IA, 64, 16, 4);
-        } else if ((pauseCtx->pageIndex == PAUSE_MAP) && kaleido_s16(&sInDungeonScene)) {
+        } else if ((pauseCtx->pageIndex == PAUSE_MAP) && sInDungeonScene) {
             // No code in this case
         } else if ((pauseCtx->pageIndex == PAUSE_QUEST) &&
                    (pauseCtx->cursorSlot[PAUSE_QUEST] == QUEST_BOMBERS_NOTEBOOK)) {
@@ -608,87 +593,75 @@ void KaleidoScope_DrawPages(PlayState* play, GraphicsContext* gfxCtx) {
     s16 stepG;
     s16 stepB;
 
-    // @recomp Manual relocation, TODO remove when recompiler handles it automatically.
-    TexturePtr* sItemPageBgTextures_reloc = KaleidoManager_GetRamAddr(&sItemPageBgTextures);
-    TexturePtr* sMapPageBgTextures_reloc = KaleidoManager_GetRamAddr(&sMapPageBgTextures);
-    TexturePtr* sQuestPageBgTextures_reloc = KaleidoManager_GetRamAddr(&sQuestPageBgTextures);
-    TexturePtr* sMaskPageBgTextures_reloc = KaleidoManager_GetRamAddr(&sMaskPageBgTextures);
-    s16* sCursorPrimR_reloc = KaleidoManager_GetRamAddr(&sCursorPrimR);
-    s16* sCursorPrimG_reloc = KaleidoManager_GetRamAddr(&sCursorPrimG);
-    s16* sCursorPrimB_reloc = KaleidoManager_GetRamAddr(&sCursorPrimB);
-    s16* sCursorEnvR_reloc = KaleidoManager_GetRamAddr(&sCursorEnvR);
-    s16* sCursorEnvG_reloc = KaleidoManager_GetRamAddr(&sCursorEnvG);
-    s16* sCursorEnvB_reloc = KaleidoManager_GetRamAddr(&sCursorEnvB);
-
     OPEN_DISPS(gfxCtx);
 
     if (!IS_PAUSE_STATE_GAMEOVER) {
         if (pauseCtx->state != PAUSE_STATE_SAVEPROMPT) {
 
             stepR =
-                ABS_ALT(*sCursorPrimR_reloc - sCursorPrimColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][0]) /
+                ABS_ALT(sCursorPrimR - sCursorPrimColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][0]) /
                 sCursorColorTimer;
             stepG =
-                ABS_ALT(*sCursorPrimG_reloc - sCursorPrimColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][1]) /
+                ABS_ALT(sCursorPrimG - sCursorPrimColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][1]) /
                 sCursorColorTimer;
             stepB =
-                ABS_ALT(*sCursorPrimB_reloc - sCursorPrimColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][2]) /
+                ABS_ALT(sCursorPrimB - sCursorPrimColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][2]) /
                 sCursorColorTimer;
 
-            if (*sCursorPrimR_reloc >= sCursorPrimColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][0]) {
-                *sCursorPrimR_reloc -= stepR;
+            if (sCursorPrimR >= sCursorPrimColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][0]) {
+                sCursorPrimR -= stepR;
             } else {
-                *sCursorPrimR_reloc += stepR;
+                sCursorPrimR += stepR;
             }
 
-            if (*sCursorPrimG_reloc >= sCursorPrimColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][1]) {
-                *sCursorPrimG_reloc -= stepG;
+            if (sCursorPrimG >= sCursorPrimColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][1]) {
+                sCursorPrimG -= stepG;
             } else {
-                *sCursorPrimG_reloc += stepG;
+                sCursorPrimG += stepG;
             }
 
-            if (*sCursorPrimB_reloc >= sCursorPrimColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][2]) {
-                *sCursorPrimB_reloc -= stepB;
+            if (sCursorPrimB >= sCursorPrimColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][2]) {
+                sCursorPrimB -= stepB;
             } else {
-                *sCursorPrimB_reloc += stepB;
+                sCursorPrimB += stepB;
             }
 
             stepR =
-                ABS_ALT(*sCursorEnvR_reloc - sCursorEnvColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][0]) /
+                ABS_ALT(sCursorEnvR - sCursorEnvColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][0]) /
                 sCursorColorTimer;
             stepG =
-                ABS_ALT(*sCursorEnvG_reloc - sCursorEnvColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][1]) /
+                ABS_ALT(sCursorEnvG - sCursorEnvColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][1]) /
                 sCursorColorTimer;
             stepB =
-                ABS_ALT(*sCursorEnvB_reloc - sCursorEnvColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][2]) /
+                ABS_ALT(sCursorEnvB - sCursorEnvColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][2]) /
                 sCursorColorTimer;
 
-            if (*sCursorEnvR_reloc >= sCursorEnvColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][0]) {
-                *sCursorEnvR_reloc -= stepR;
+            if (sCursorEnvR >= sCursorEnvColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][0]) {
+                sCursorEnvR -= stepR;
             } else {
-                *sCursorEnvR_reloc += stepR;
+                sCursorEnvR += stepR;
             }
 
-            if (*sCursorEnvG_reloc >= sCursorEnvColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][1]) {
-                *sCursorEnvG_reloc -= stepG;
+            if (sCursorEnvG >= sCursorEnvColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][1]) {
+                sCursorEnvG -= stepG;
             } else {
-                *sCursorEnvG_reloc += stepG;
+                sCursorEnvG += stepG;
             }
 
-            if (*sCursorEnvB_reloc >= sCursorEnvColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][2]) {
-                *sCursorEnvB_reloc -= stepB;
+            if (sCursorEnvB >= sCursorEnvColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][2]) {
+                sCursorEnvB -= stepB;
             } else {
-                *sCursorEnvB_reloc += stepB;
+                sCursorEnvB += stepB;
             }
 
             sCursorColorTimer--;
             if (sCursorColorTimer == 0) {
-                *sCursorPrimR_reloc = sCursorPrimColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][0];
-                *sCursorPrimG_reloc = sCursorPrimColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][1];
-                *sCursorPrimB_reloc = sCursorPrimColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][2];
-                *sCursorEnvR_reloc = sCursorEnvColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][0];
-                *sCursorEnvG_reloc = sCursorEnvColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][1];
-                *sCursorEnvB_reloc = sCursorEnvColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][2];
+                sCursorPrimR = sCursorPrimColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][0];
+                sCursorPrimG = sCursorPrimColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][1];
+                sCursorPrimB = sCursorPrimColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][2];
+                sCursorEnvR = sCursorEnvColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][0];
+                sCursorEnvG = sCursorEnvColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][1];
+                sCursorEnvB = sCursorEnvColorTarget[pauseCtx->cursorColorSet + sCursorColorTargetIndex][2];
                 sCursorColorTargetIndex ^= 1;
                 sCursorColorTimer = 10;
             }
@@ -704,14 +677,13 @@ void KaleidoScope_DrawPages(PlayState* play, GraphicsContext* gfxCtx) {
             gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 180, 180, 120, 255);
 
             Matrix_RotateYF(0.0f, MTXMODE_NEW);
-            // @recomp Manual relocation, TODO remove when automated.
-            Matrix_Translate(0.0f, kaleido_f32(&sPauseMenuVerticalOffset) / 100.0f, -93.0f, MTXMODE_APPLY);
+            Matrix_Translate(0.0f, sPauseMenuVerticalOffset / 100.0f, -93.0f, MTXMODE_APPLY);
             Matrix_Scale(0.78f, 0.78f, 0.78f, MTXMODE_APPLY);
             Matrix_RotateXFApply(-pauseCtx->itemPageRoll / 100.0f);
 
             gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
-            POLY_OPA_DISP = KaleidoScope_DrawPageSections(POLY_OPA_DISP, pauseCtx->itemPageVtx, sItemPageBgTextures_reloc);
+            POLY_OPA_DISP = KaleidoScope_DrawPageSections(POLY_OPA_DISP, pauseCtx->itemPageVtx, sItemPageBgTextures);
 
             KaleidoScope_DrawItemSelect(play);
         }
@@ -726,16 +698,15 @@ void KaleidoScope_DrawPages(PlayState* play, GraphicsContext* gfxCtx) {
             gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 180, 180, 120, 255);
 
             Matrix_RotateYF(-1.57f, MTXMODE_NEW);
-            // @recomp Manual relocation, TODO remove when automated.
-            Matrix_Translate(0.0f, kaleido_f32(&sPauseMenuVerticalOffset) / 100.0f, -93.0f, MTXMODE_APPLY);
+            Matrix_Translate(0.0f, sPauseMenuVerticalOffset / 100.0f, -93.0f, MTXMODE_APPLY);
             Matrix_Scale(0.78f, 0.78f, 0.78f, MTXMODE_APPLY);
             Matrix_RotateXFApply(-pauseCtx->mapPageRoll / 100.0f);
 
             gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
-            POLY_OPA_DISP = KaleidoScope_DrawPageSections(POLY_OPA_DISP, pauseCtx->mapPageVtx, sMapPageBgTextures_reloc);
+            POLY_OPA_DISP = KaleidoScope_DrawPageSections(POLY_OPA_DISP, pauseCtx->mapPageVtx, sMapPageBgTextures);
 
-            if (kaleido_s16(&sInDungeonScene)) {
+            if (sInDungeonScene) {
                 KaleidoScope_DrawDungeonMap(play);
                 Gfx_SetupDL42_Opa(gfxCtx);
                 gDPSetCombineMode(POLY_OPA_DISP++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
@@ -757,14 +728,13 @@ void KaleidoScope_DrawPages(PlayState* play, GraphicsContext* gfxCtx) {
             gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 180, 180, 120, 255);
 
             Matrix_RotateYF(-3.14f, MTXMODE_NEW);
-            // @recomp Manual relocation, TODO remove when automated.
-            Matrix_Translate(0.0f, kaleido_f32(&sPauseMenuVerticalOffset) / 100.0f, -93.0f, MTXMODE_APPLY);
+            Matrix_Translate(0.0f, sPauseMenuVerticalOffset / 100.0f, -93.0f, MTXMODE_APPLY);
             Matrix_Scale(0.78f, 0.78f, 0.78f, MTXMODE_APPLY);
             Matrix_RotateXFApply(-pauseCtx->questPageRoll / 100.0f);
 
             gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
-            POLY_OPA_DISP = KaleidoScope_DrawPageSections(POLY_OPA_DISP, pauseCtx->questPageVtx, sQuestPageBgTextures_reloc);
+            POLY_OPA_DISP = KaleidoScope_DrawPageSections(POLY_OPA_DISP, pauseCtx->questPageVtx, sQuestPageBgTextures);
 
             KaleidoScope_DrawQuestStatus(play);
         }
@@ -781,14 +751,13 @@ void KaleidoScope_DrawPages(PlayState* play, GraphicsContext* gfxCtx) {
             gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 180, 180, 120, 255);
 
             Matrix_RotateYF(1.57f, MTXMODE_NEW);
-            // @recomp Manual relocation, TODO remove when automated.
-            Matrix_Translate(0.0f, kaleido_f32(&sPauseMenuVerticalOffset) / 100.0f, -93.0f, MTXMODE_APPLY);
+            Matrix_Translate(0.0f, sPauseMenuVerticalOffset / 100.0f, -93.0f, MTXMODE_APPLY);
             Matrix_Scale(0.78f, 0.78f, 0.78f, MTXMODE_APPLY);
             Matrix_RotateXFApply(-pauseCtx->maskPageRoll / 100.0f);
 
             gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
-            POLY_OPA_DISP = KaleidoScope_DrawPageSections(POLY_OPA_DISP, pauseCtx->maskPageVtx, sMaskPageBgTextures_reloc);
+            POLY_OPA_DISP = KaleidoScope_DrawPageSections(POLY_OPA_DISP, pauseCtx->maskPageVtx, sMaskPageBgTextures);
 
             KaleidoScope_DrawMaskSelect(play);
         }
@@ -804,15 +773,14 @@ void KaleidoScope_DrawPages(PlayState* play, GraphicsContext* gfxCtx) {
                     gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 180, 180, 120, 255);
 
                     Matrix_RotateYF(0.0f, MTXMODE_NEW);
-                    // @recomp Manual relocation, TODO remove when automated.
-                    Matrix_Translate(0.0f, kaleido_f32(&sPauseMenuVerticalOffset) / 100.0f, -93.0f, MTXMODE_APPLY);
+                    Matrix_Translate(0.0f, sPauseMenuVerticalOffset / 100.0f, -93.0f, MTXMODE_APPLY);
                     Matrix_Scale(0.78f, 0.78f, 0.78f, MTXMODE_APPLY);
                     Matrix_RotateXFApply(-pauseCtx->itemPageRoll / 100.0f);
 
                     gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
                     POLY_OPA_DISP =
-                        KaleidoScope_DrawPageSections(POLY_OPA_DISP, pauseCtx->itemPageVtx, sItemPageBgTextures_reloc);
+                        KaleidoScope_DrawPageSections(POLY_OPA_DISP, pauseCtx->itemPageVtx, sItemPageBgTextures);
 
                     KaleidoScope_DrawItemSelect(play);
                 }
@@ -827,16 +795,15 @@ void KaleidoScope_DrawPages(PlayState* play, GraphicsContext* gfxCtx) {
                 gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 180, 180, 120, 255);
 
                 Matrix_RotateYF(-1.57f, MTXMODE_NEW);
-                // @recomp Manual relocation, TODO remove when automated.
-                Matrix_Translate(0.0f, kaleido_f32(&sPauseMenuVerticalOffset) / 100.0f, -93.0f, MTXMODE_APPLY);
+                Matrix_Translate(0.0f, sPauseMenuVerticalOffset / 100.0f, -93.0f, MTXMODE_APPLY);
                 Matrix_Scale(0.78f, 0.78f, 0.78f, MTXMODE_APPLY);
                 Matrix_RotateXFApply(-pauseCtx->mapPageRoll / 100.0f);
 
                 gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
-                POLY_OPA_DISP = KaleidoScope_DrawPageSections(POLY_OPA_DISP, pauseCtx->mapPageVtx, sMapPageBgTextures_reloc);
+                POLY_OPA_DISP = KaleidoScope_DrawPageSections(POLY_OPA_DISP, pauseCtx->mapPageVtx, sMapPageBgTextures);
 
-                if (kaleido_s16(&sInDungeonScene)) {
+                if (sInDungeonScene) {
                     KaleidoScope_DrawDungeonMap(play);
                     Gfx_SetupDL42_Opa(gfxCtx);
 
@@ -878,15 +845,14 @@ void KaleidoScope_DrawPages(PlayState* play, GraphicsContext* gfxCtx) {
                 gDPSetTextureFilter(POLY_OPA_DISP++, G_TF_BILERP);
 
                 Matrix_RotateYF(-3.14f, MTXMODE_NEW);
-                // @recomp Manual relocation, TODO remove when automated.
-                Matrix_Translate(0.0f, kaleido_f32(&sPauseMenuVerticalOffset) / 100.0f, -93.0f, MTXMODE_APPLY);
+                Matrix_Translate(0.0f, sPauseMenuVerticalOffset / 100.0f, -93.0f, MTXMODE_APPLY);
                 Matrix_Scale(0.78f, 0.78f, 0.78f, MTXMODE_APPLY);
                 Matrix_RotateXFApply(-pauseCtx->questPageRoll / 100.0f);
 
                 gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
                 POLY_OPA_DISP =
-                    KaleidoScope_DrawPageSections(POLY_OPA_DISP, pauseCtx->questPageVtx, sQuestPageBgTextures_reloc);
+                    KaleidoScope_DrawPageSections(POLY_OPA_DISP, pauseCtx->questPageVtx, sQuestPageBgTextures);
 
                 KaleidoScope_DrawQuestStatus(play);
                 break;
@@ -900,15 +866,14 @@ void KaleidoScope_DrawPages(PlayState* play, GraphicsContext* gfxCtx) {
                 gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 180, 180, 120, 255);
 
                 Matrix_RotateYF(1.57f, MTXMODE_NEW);
-                // @recomp Manual relocation, TODO remove when automated.
-                Matrix_Translate(0.0f, kaleido_f32(&sPauseMenuVerticalOffset) / 100.0f, -93.0f, MTXMODE_APPLY);
+                Matrix_Translate(0.0f, sPauseMenuVerticalOffset / 100.0f, -93.0f, MTXMODE_APPLY);
                 Matrix_Scale(0.78f, 0.78f, 0.78f, MTXMODE_APPLY);
                 Matrix_RotateXFApply(-pauseCtx->maskPageRoll / 100.0f);
 
                 gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
                 POLY_OPA_DISP =
-                    KaleidoScope_DrawPageSections(POLY_OPA_DISP, pauseCtx->maskPageVtx, sMaskPageBgTextures_reloc);
+                    KaleidoScope_DrawPageSections(POLY_OPA_DISP, pauseCtx->maskPageVtx, sMaskPageBgTextures);
 
                 KaleidoScope_DrawMaskSelect(play);
                 break;

--- a/patches/ui_transform_tagging.c
+++ b/patches/ui_transform_tagging.c
@@ -199,6 +199,13 @@ void KaleidoScope_DrawCursor(PlayState* play) {
     CLOSE_DISPS(play->state.gfxCtx);
 }
 
+extern s16 sPauseZRCursorColorTimer; // 8082B9C8 32899 -17976
+extern s16 sPauseZRCursorColorIndex; // 8082B9CC 32899 -17972
+extern s16 sPauseZRCursorRed; // 8082DA50 32899 -9648
+extern s16 sPauseZRCursorGreen; // 8082DA52 32899 -9646
+extern s16 sPauseZRCursorBlue; // 8082DA54 32899 -9644
+extern s16 sPauseZRCursorAlpha; // 8082DA56 32899 -9642
+
 /**
  * infoPanelVtx
  * 
@@ -213,16 +220,11 @@ void KaleidoScope_DrawCursor(PlayState* play) {
 
 // @recomp Patched to tag the matrix for interpolating the vertices of the Z button, R button, and name panel.
 void KaleidoScope_DrawInfoPanel(PlayState* play) {
-    static s16 sPauseZRCursorColorTargets[][4] = {
+    static const s16 sPauseZRCursorColorTargets[][4] = {
         { 180, 210, 255, 220 },
         { 100, 100, 150, 220 },
     };
-    static s16 sPauseZRCursorColorTimer = 20;
-    static s16 sPauseZRCursorColorIndex = 0;
-    static s16 sPauseZRCursorRed;
-    static s16 sPauseZRCursorGreen;
-    static s16 sPauseZRCursorBlue;
-    static s16 sPauseZRCursorAlpha;
+    // @recomp Moved non-const function-local statics to externs so they still get reset on overlay load.
     PauseContext* pauseCtx = &play->pauseCtx;
     s16 stepR;
     s16 stepG;

--- a/src/main/rt64_render_context.cpp
+++ b/src/main/rt64_render_context.cpp
@@ -268,7 +268,7 @@ zelda64::renderer::RT64Context::RT64Context(uint8_t* rdram, ultramodern::rendere
 
     // Check if the selected device actually supports MSAA sample positions and MSAA for for the formats that will be used
     // and downgrade the configuration accordingly.
-    if (true) {//app->device->getCapabilities().sampleLocations) {
+    if (app->device->getCapabilities().sampleLocations) {
         RT64::RenderSampleCounts color_sample_counts = app->device->getSampleCountsSupported(RT64::RenderFormat::R8G8B8A8_UNORM);
         RT64::RenderSampleCounts depth_sample_counts = app->device->getSampleCountsSupported(RT64::RenderFormat::D32_FLOAT);
         RT64::RenderSampleCounts common_sample_counts = color_sample_counts & depth_sample_counts;

--- a/src/main/rt64_render_context.cpp
+++ b/src/main/rt64_render_context.cpp
@@ -268,7 +268,7 @@ zelda64::renderer::RT64Context::RT64Context(uint8_t* rdram, ultramodern::rendere
 
     // Check if the selected device actually supports MSAA sample positions and MSAA for for the formats that will be used
     // and downgrade the configuration accordingly.
-    if (app->device->getCapabilities().sampleLocations) {
+    if (true) {//app->device->getCapabilities().sampleLocations) {
         RT64::RenderSampleCounts color_sample_counts = app->device->getSampleCountsSupported(RT64::RenderFormat::R8G8B8A8_UNORM);
         RT64::RenderSampleCounts depth_sample_counts = app->device->getSampleCountsSupported(RT64::RenderFormat::D32_FLOAT);
         RT64::RenderSampleCounts common_sample_counts = color_sample_counts & depth_sample_counts;

--- a/us.rev1.toml
+++ b/us.rev1.toml
@@ -5,7 +5,7 @@ entrypoint = 0x80080000
 # Paths are relative to the location of this config file.
 output_func_path = "RecompiledFuncs"
 relocatable_sections_path = "overlays.us.rev1.txt"
-symbols_file_path = "us.rev1.syms.toml"
+symbols_file_path = "Zelda64RecompSyms/mm.us.rev1.syms.toml"
 rom_file_path = "mm.us.rev1.rom_uncompressed.z64"
 
 [patches]


### PR DESCRIPTION
This PR incorporates some new upgrades to the recompiler to simplify building and writing patches.
* The patch recompilation process now uses symbol reference files (found [here]()), eliminating the decompilation .elf requirement for building this project.
* Patch recompilation now resolves relocations automatically instead of needing the author to manually handle each one.