### PR TITLE
Implement setting for special item HUD.

### DIFF
--- a/assets/config_menu/graphics.rml
+++ b/assets/config_menu/graphics.rml
@@ -239,7 +239,7 @@
                                 data-checked="hr_option"
                                 value="Original"
                                 id="hr_original"
-                                style="nav-up: #msaa_none; nav-down: #apply_button"
+                                style="nav-up: #msaa_none; nav-down: #special_item_hud_enabled"
                             />
                             <label class="config-option__tab-label" for="hr_original">Original</label>
                             <input type="radio"
@@ -249,7 +249,7 @@
                                 data-checked="hr_option"
                                 value="Clamp16x9"
                                 id="hr_16_9"
-                                style="nav-up: #msaa_2x; nav-down: #apply_button"
+                                style="nav-up: #msaa_2x; nav-down: #special_item_hud_enabled"
                                 data-style-nav-up="msaa2x_supported ? '#msaa_2x' : '#msaa_none'"
                             />
                             <label class="config-option__tab-label" for="hr_16_9">16:9</label>
@@ -260,12 +260,38 @@
                                 data-checked="hr_option"
                                 value="Full"
                                 id="hr_full"
-                                style="nav-up: #msaa_4x; nav-down: #apply_button"
+                                style="nav-up: #msaa_4x; nav-down: #special_item_hud_disabled"
                                 data-style-nav-up="msaa4x_supported ? '#msaa_4x' : (msaa2x_supported ? '#msaa_2x' : '#msaa_none')"
                             />
                             <label class="config-option__tab-label" for="hr_full">Expand</label>
                         </div>
                     </div>
+
+					<div class="config-option" data-event-mouseover="set_cur_config_index(7)">
+						<label class="config-option__title">Special Item HUD</label>
+						<div class="config-option__list">
+							<input type="radio"
+                                data-event-blur="set_cur_config_index(-1)"
+                                data-event-focus="set_cur_config_index(7)"
+                                name="special_item_hud_option"
+                                data-checked="special_item_hud_option"
+                                value="On"
+                                id="special_item_hud_enabled"
+                                style="nav-up: #hr_original; nav-down: #apply_button"
+                            />
+							<label class="config-option__tab-label" for="special_item_hud_enabled">On</label>
+							<input type="radio"
+                                data-event-blur="set_cur_config_index(-1)"
+                                data-event-focus="set_cur_config_index(7)"
+                                name="special_item_hud_option"
+                                data-checked="special_item_hud_option"
+                                value="Off"
+                                id="special_item_hud_disabled"
+                                style="nav-up: #hr_16_9; nav-down: #apply_button"
+                            />
+							<label class="config-option__tab-label" for="special_item_hud_disabled">Off</label>
+						</div>
+					</div>
 
                 </div>
                 <div class="config__wrapper">
@@ -302,6 +328,9 @@
                     <p data-if="cur_config_index == 6">
                         Adjusts the placement of HUD elements to fit the selected aspect ratio. <b>Expand</b> will use the aspect ratio of the game's output window.
                     </p>
+					<p data-if="cur_config_index == 7">
+						Enables visibility of the special item HUD. Affects visibility only, functionality can be modified in the <b>Controls</b> setting tab.
+					</p>
                 </div>
             </div>
             <div class="config__footer">
@@ -314,7 +343,7 @@
                         data-attrif-disabled="!options_changed"
                         onclick="apply_options"
                         id="apply_button"
-                        style="nav-up:#hr_original"
+                        style="nav-up:#special_item_hud_enabled"
                     >
                         <div class="button__label">Apply<span class="prompt-font-sm">{{gfx_help__apply}}</span></div>
                     </button>

--- a/include/zelda_config.h
+++ b/include/zelda_config.h
@@ -35,6 +35,17 @@ namespace zelda64 {
         {zelda64::AutosaveMode::Off, "Off"}
     });
 
+    enum class SpecialItemHudMode {
+        On,
+        Off,
+        OptionCount
+    };
+
+    NLOHMANN_JSON_SERIALIZE_ENUM(zelda64::SpecialItemHudMode, {
+        {zelda64::SpecialItemHudMode::On, "On"},
+        {zelda64::SpecialItemHudMode::Off, "Off"}
+        });
+
     enum class TargetingMode {
         Switch,
         Hold,
@@ -83,6 +94,8 @@ namespace zelda64 {
 
     AutosaveMode get_autosave_mode();
     void set_autosave_mode(AutosaveMode mode);
+
+    SpecialItemHudMode get_special_item_hud_mode();
 
     AnalogCamMode get_analog_cam_mode();
     void set_analog_cam_mode(AnalogCamMode mode);

--- a/patches/misc_funcs.h
+++ b/patches/misc_funcs.h
@@ -11,5 +11,6 @@ DECLARE_FUNC(void, recomp_handle_quicksave_actions_main, OSMesgQueue* enter_mq, 
 DECLARE_FUNC(u16, recomp_get_pending_warp);
 DECLARE_FUNC(u32, recomp_get_pending_set_time);
 DECLARE_FUNC(s32, recomp_autosave_enabled);
+DECLARE_FUNC(s32, recomp_special_item_hud_on);
 
 #endif

--- a/patches/syms.ld
+++ b/patches/syms.ld
@@ -44,3 +44,4 @@ recomp_get_inverted_axes = 0x8F0000A4;
 recomp_high_precision_fb_enabled = 0x8F0000A8;
 recomp_get_resolution_scale = 0x8F0000AC;
 recomp_get_analog_inverted_axes = 0x8F0000B0;
+recomp_special_item_hud_on = 0x8F0000B4;

--- a/patches/ui_patches.c
+++ b/patches/ui_patches.c
@@ -3,6 +3,7 @@
 #include "buffers.h"
 #include "sys_cfb.h"
 #include "overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_scope.h"
+#include "misc_funcs.h"
 
 // This moves elements towards the screen edges when increased
 s32 margin_reduction = 8;
@@ -488,8 +489,10 @@ void Interface_Draw(PlayState* play) {
         
         // @recomp Draw the D-Pad and its item icons as well as the autosave icon if the game is unpaused.
         if (pauseCtx->state != PAUSE_STATE_MAIN) {
-            draw_dpad(play);
-            draw_dpad_icons(play);
+            if (recomp_special_item_hud_on()) {
+                draw_dpad(play);
+                draw_dpad_icons(play);
+            }
             draw_autosave_icon(play);
         }
 

--- a/src/game/config.cpp
+++ b/src/game/config.cpp
@@ -23,6 +23,7 @@ constexpr std::u8string_view program_id = u8"Zelda64Recompiled";
 
 constexpr auto res_default            = ultramodern::renderer::Resolution::Auto;
 constexpr auto hr_default             = ultramodern::renderer::HUDRatioMode::Clamp16x9;
+constexpr auto special_item_hud_default = ultramodern::renderer::SpecialItemHUD::On;
 constexpr auto api_default            = ultramodern::renderer::GraphicsApi::Auto;
 constexpr auto ar_default             = ultramodern::renderer::AspectRatio::Expand;
 constexpr auto msaa_default           = ultramodern::renderer::Antialiasing::MSAA2X;
@@ -92,6 +93,7 @@ namespace ultramodern {
             {"res_option",      config.res_option},
             {"wm_option",       config.wm_option},
             {"hr_option",       config.hr_option},
+            {"special_item_hud_option",     config.special_item_hud_option},
             {"api_option",      config.api_option},
             {"ds_option",       config.ds_option},
             {"ar_option",       config.ar_option},
@@ -107,6 +109,7 @@ namespace ultramodern {
         config.res_option       = from_or_default(j, "res_option",      res_default);
         config.wm_option        = from_or_default(j, "wm_option",       wm_default());
         config.hr_option        = from_or_default(j, "hr_option",       hr_default);
+        config.special_item_hud_option = from_or_default(j, "special_item_hud_option", special_item_hud_default);
         config.api_option       = from_or_default(j, "api_option",      api_default);
         config.ds_option        = from_or_default(j, "ds_option",       ds_default);
         config.ar_option        = from_or_default(j, "ar_option",       ar_default);
@@ -323,6 +326,7 @@ void reset_graphics_options() {
     new_config.res_option = res_default;
     new_config.wm_option = wm_default();
     new_config.hr_option = hr_default;
+    new_config.special_item_hud_option = special_item_hud_default;
     new_config.ds_option = ds_default;
     new_config.ar_option = ar_default;
     new_config.msaa_option = msaa_default;

--- a/src/game/recomp_api.cpp
+++ b/src/game/recomp_api.cpp
@@ -95,6 +95,10 @@ extern "C" void recomp_autosave_enabled(uint8_t* rdram, recomp_context* ctx) {
     _return(ctx, static_cast<s32>(zelda64::get_autosave_mode() == zelda64::AutosaveMode::On));
 }
 
+extern "C" void recomp_special_item_hud_on(uint8_t * rdram, recomp_context * ctx) {
+    _return(ctx, static_cast<s32>(zelda64::get_special_item_hud_mode() == zelda64::SpecialItemHudMode::On));
+}
+
 extern "C" void recomp_load_overlays(uint8_t * rdram, recomp_context * ctx) {
     u32 rom = _arg<0, u32>(rdram, ctx);
     PTR(void) ram = _arg<1, PTR(void)>(rdram, ctx);

--- a/src/main/rt64_render_context.cpp
+++ b/src/main/rt64_render_context.cpp
@@ -146,6 +146,16 @@ void set_application_user_config(RT64::Application* application, const ultramode
             break;
     }
 
+    switch (config.special_item_hud_option) {
+        default:
+        case ultramodern::renderer::SpecialItemHUD::On:
+            application->userConfig.specialItemHud = true;
+            break;
+        case ultramodern::renderer::SpecialItemHUD::Off:
+            application->userConfig.specialItemHud = false;
+            break;
+    }
+
     application->userConfig.aspectRatio = to_rt64(config.ar_option);
     application->userConfig.antialiasing = to_rt64(config.msaa_option);
     application->userConfig.refreshRate = to_rt64(config.rr_option);

--- a/src/ui/ui_config.cpp
+++ b/src/ui/ui_config.cpp
@@ -288,6 +288,7 @@ struct ControlOptionsContext {
     zelda64::TargetingMode targeting_mode;
 	recomp::BackgroundInputMode background_input_mode;
 	zelda64::AutosaveMode autosave_mode;
+	zelda64::SpecialItemHudMode special_item_hud_mode;
     zelda64::CameraInvertMode camera_invert_mode;
 	zelda64::AnalogCamMode analog_cam_mode;
     zelda64::CameraInvertMode analog_camera_invert_mode;
@@ -375,6 +376,18 @@ void zelda64::set_autosave_mode(zelda64::AutosaveMode mode) {
 	control_options_context.autosave_mode = mode;
 	if (general_model_handle) {
 		general_model_handle.DirtyVariable("autosave_mode");
+	}
+}
+
+zelda64::SpecialItemHudMode zelda64::get_special_item_hud_mode() {
+	switch (new_options.special_item_hud_option) {
+		default:
+		case ultramodern::renderer::SpecialItemHUD::On:
+			return zelda64::SpecialItemHudMode::On;
+			break;
+		case ultramodern::renderer::SpecialItemHUD::Off:
+			return zelda64::SpecialItemHudMode::Off;
+			break;
 	}
 }
 
@@ -637,6 +650,7 @@ public:
 		bind_option(constructor, "wm_option", &new_options.wm_option);
 		bind_option(constructor, "ar_option", &new_options.ar_option);
 		bind_option(constructor, "hr_option", &new_options.hr_option);
+		bind_option(constructor, "special_item_hud_option", &new_options.special_item_hud_option);
 		bind_option(constructor, "msaa_option", &new_options.msaa_option);
 		bind_option(constructor, "rr_option", &new_options.rr_option);
 		constructor.BindFunc("rr_manual_value",


### PR DESCRIPTION
Based on issue: https://github.com/Zelda64Recomp/Zelda64Recomp/issues/168
Was marked as "good first issue" so I gave it a try.

![image](https://github.com/user-attachments/assets/ee99017c-4b9d-4f8f-bbf2-d309245a65bf)

![image](https://github.com/user-attachments/assets/4f7381d9-7be7-4f59-8365-9bc7a35f7989)

Testing I did:

- Setting persists after toggle On and Off and after application exist and restart.
- Toggle shows and hides the "special item hud" based on setting when changed during gameplay.
- Navigating menu with arrows works without skipping any menu items.