### PR TITLE
Implement special item hud toggle.

### DIFF
--- a/assets/config_menu/general.rml
+++ b/assets/config_menu/general.rml
@@ -1,402 +1,402 @@
 <template name="config-menu__general">
-	<head>
-	</head>
-	<body>
-		<form class="config__form" id="conf-general__form">
-			<div class="config__hz-wrapper" id="conf-general__hz-wrapper">
-				<!-- Options -->
-				<div class="config__wrapper" data-event-mouseout="set_cur_config_index(-1)" id="conf-general__wrapper" style="overflow:auto;max-height:100%">
-					<!-- targeting mode -->
-					<div class="config-option" data-event-mouseover="set_cur_config_index(0)" id="conf-general__Targeting-Mode">
-						<label class="config-option__title">Targeting Mode</label>
-						<div class="config-option__list">
-							<input
-								type="radio"
-								data-event-blur="set_cur_config_index(-1)"
-								data-event-focus="set_cur_config_index(0)"
-								name="targeting_mode"
-								data-checked="targeting_mode"
-								value="Switch"
-								id="tm_switch"
-								style="nav-up: #tab_general; nav-down: #rumble_strength_input"
+    <head>
+    </head>
+    <body>
+        <form class="config__form" id="conf-general__form">
+            <div class="config__hz-wrapper" id="conf-general__hz-wrapper">
+                <!-- Options -->
+                <div class="config__wrapper" data-event-mouseout="set_cur_config_index(-1)" id="conf-general__wrapper" style="overflow:auto;max-height:100%">
+                    <!-- targeting mode -->
+                    <div class="config-option" data-event-mouseover="set_cur_config_index(0)" id="conf-general__Targeting-Mode">
+                        <label class="config-option__title">Targeting Mode</label>
+                        <div class="config-option__list">
+                            <input
+                                type="radio"
+                                data-event-blur="set_cur_config_index(-1)"
+                                data-event-focus="set_cur_config_index(0)"
+                                name="targeting_mode"
+                                data-checked="targeting_mode"
+                                value="Switch"
+                                id="tm_switch"
+                                style="nav-up: #tab_general; nav-down: #rumble_strength_input"
                             />
-							<label class="config-option__tab-label" for="tm_switch">Switch</label>
+                            <label class="config-option__tab-label" for="tm_switch">Switch</label>
 
-							<input
-								type="radio"
-								data-event-blur="set_cur_config_index(-1)"
-								data-event-focus="set_cur_config_index(0)"
-								name="targeting_mode"
-								data-checked="targeting_mode"
-								value="Hold"
-								id="tm_hold"
-								style="nav-up: #tab_general; nav-down: #rumble_strength_input"
+                            <input
+                                type="radio"
+                                data-event-blur="set_cur_config_index(-1)"
+                                data-event-focus="set_cur_config_index(0)"
+                                name="targeting_mode"
+                                data-checked="targeting_mode"
+                                value="Hold"
+                                id="tm_hold"
+                                style="nav-up: #tab_general; nav-down: #rumble_strength_input"
                             />
-							<label class="config-option__tab-label" for="tm_hold">Hold</label>
-						</div>
-					</div>
+                            <label class="config-option__tab-label" for="tm_hold">Hold</label>
+                        </div>
+                    </div>
 
-					<!-- rumble strength -->
-					<div class="config-option" data-event-mouseover="set_cur_config_index(1)">
-						<label class="config-option__title">Rumble Strength</label>
-						<div class="config-option__range-wrapper config-option__list">
-							<label class="config-option__range-label">{{rumble_strength}}%</label>
-							<input
-								class="nav-vert"
-								data-event-blur="set_cur_config_index(-1)"
-								data-event-focus="set_cur_config_index(1)"
-								id="rumble_strength_input"
-								type="range"
-								min="0"
-								max="100"
-								style="flex: 1; margin: 0dp;"
-								data-value="rumble_strength"
+                    <!-- rumble strength -->
+                    <div class="config-option" data-event-mouseover="set_cur_config_index(1)">
+                        <label class="config-option__title">Rumble Strength</label>
+                        <div class="config-option__range-wrapper config-option__list">
+                            <label class="config-option__range-label">{{rumble_strength}}%</label>
+                            <input
+                                class="nav-vert"
+                                data-event-blur="set_cur_config_index(-1)"
+                                data-event-focus="set_cur_config_index(1)"
+                                id="rumble_strength_input"
+                                type="range"
+                                min="0"
+                                max="100"
+                                style="flex: 1; margin: 0dp;"
+                                data-value="rumble_strength"
                             />
-						</div>
-					</div>
+                        </div>
+                    </div>
 
-					<!-- gyro sensitivity -->
-					<div class="config-option" data-event-mouseover="set_cur_config_index(2)">
-						<label class="config-option__title">Gyro Sensitivity</label>
-						<div class="config-option__range-wrapper config-option__list">
-							<label class="config-option__range-label">{{gyro_sensitivity}}%</label>
-							<input
-								class="nav-vert"
-								data-event-blur="set_cur_config_index(-1)"
-								data-event-focus="set_cur_config_index(2)"
-								id="gyro_sensitivity_input"
-								type="range"
-								min="0"
-								max="100"
-								style="flex: 1; margin: 0dp;"
-								data-value="gyro_sensitivity"
+                    <!-- gyro sensitivity -->
+                    <div class="config-option" data-event-mouseover="set_cur_config_index(2)">
+                        <label class="config-option__title">Gyro Sensitivity</label>
+                        <div class="config-option__range-wrapper config-option__list">
+                            <label class="config-option__range-label">{{gyro_sensitivity}}%</label>
+                            <input
+                                class="nav-vert"
+                                data-event-blur="set_cur_config_index(-1)"
+                                data-event-focus="set_cur_config_index(2)"
+                                id="gyro_sensitivity_input"
+                                type="range"
+                                min="0"
+                                max="100"
+                                style="flex: 1; margin: 0dp;"
+                                data-value="gyro_sensitivity"
                             />
-						</div>
-					</div>
+                        </div>
+                    </div>
 
-					<!-- mouse sensitivity -->
-					<div class="config-option" data-event-mouseover="set_cur_config_index(3)">
-						<label class="config-option__title">Mouse Sensitivity</label>
-						<div class="config-option__range-wrapper config-option__list">
-							<label class="config-option__range-label">{{mouse_sensitivity}}%</label>
-							<input
-								class="nav-vert"
-								data-event-blur="set_cur_config_index(-1)"
-								data-event-focus="set_cur_config_index(3)"
-								id="mouse_sensitivity_input"
-								type="range"
-								min="0"
-								max="100"
-								style="flex: 1; margin: 0dp;"
-								data-value="mouse_sensitivity"
+                    <!-- mouse sensitivity -->
+                    <div class="config-option" data-event-mouseover="set_cur_config_index(3)">
+                        <label class="config-option__title">Mouse Sensitivity</label>
+                        <div class="config-option__range-wrapper config-option__list">
+                            <label class="config-option__range-label">{{mouse_sensitivity}}%</label>
+                            <input
+                                class="nav-vert"
+                                data-event-blur="set_cur_config_index(-1)"
+                                data-event-focus="set_cur_config_index(3)"
+                                id="mouse_sensitivity_input"
+                                type="range"
+                                min="0"
+                                max="100"
+                                style="flex: 1; margin: 0dp;"
+                                data-value="mouse_sensitivity"
                             />
-						</div>
-					</div>
+                        </div>
+                    </div>
 
-					<!-- joystick deadzone -->
-					<div class="config-option" data-event-mouseover="set_cur_config_index(4)">
-						<label class="config-option__title">Joystick Deadzone</label>
-						<div class="config-option__range-wrapper config-option__list">
-							<label class="config-option__range-label">{{joystick_deadzone}}%</label>
-							<input
-								class="nav-vert"
-								data-event-blur="set_cur_config_index(-1)"
-								data-event-focus="set_cur_config_index(4)"
-								id="joystick_deadzone_input"
-								type="range"
-								min="0"
-								max="100"
-								style="flex: 1; margin: 0dp; nav-down: #bg_input_enabled"
-								data-value="joystick_deadzone"
+                    <!-- joystick deadzone -->
+                    <div class="config-option" data-event-mouseover="set_cur_config_index(4)">
+                        <label class="config-option__title">Joystick Deadzone</label>
+                        <div class="config-option__range-wrapper config-option__list">
+                            <label class="config-option__range-label">{{joystick_deadzone}}%</label>
+                            <input
+                                class="nav-vert"
+                                data-event-blur="set_cur_config_index(-1)"
+                                data-event-focus="set_cur_config_index(4)"
+                                id="joystick_deadzone_input"
+                                type="range"
+                                min="0"
+                                max="100"
+                                style="flex: 1; margin: 0dp; nav-down: #bg_input_enabled"
+                                data-value="joystick_deadzone"
                             />
-						</div>
-					</div>
+                        </div>
+                    </div>
 
-					<!-- background input -->
-					<div class="config-option" data-event-mouseover="set_cur_config_index(5)" id="conf-general__Background-Input">
-						<label class="config-option__title">Background Input</label>
-						<div class="config-option__list">
-							<input
-								type="radio"
-								data-event-blur="set_cur_config_index(-1)"
-								data-event-focus="set_cur_config_index(5)"
-								name="background_input_mode"
-								data-checked="background_input_mode"
-								value="On"
-								id="bg_input_enabled"
-								style="nav-up: #joystick_deadzone_input; nav-down: #autosave_enabled"
+                    <!-- background input -->
+                    <div class="config-option" data-event-mouseover="set_cur_config_index(5)" id="conf-general__Background-Input">
+                        <label class="config-option__title">Background Input</label>
+                        <div class="config-option__list">
+                            <input
+                                type="radio"
+                                data-event-blur="set_cur_config_index(-1)"
+                                data-event-focus="set_cur_config_index(5)"
+                                name="background_input_mode"
+                                data-checked="background_input_mode"
+                                value="On"
+                                id="bg_input_enabled"
+                                style="nav-up: #joystick_deadzone_input; nav-down: #autosave_enabled"
                             />
-							<label class="config-option__tab-label" for="bg_input_enabled">On</label>
+                            <label class="config-option__tab-label" for="bg_input_enabled">On</label>
 
-							<input
-								type="radio"
-								data-event-blur="set_cur_config_index(-1)"
-								data-event-focus="set_cur_config_index(5)"
-								name="background_input_mode"
-								data-checked="background_input_mode"
-								value="Off"
-								id="bg_input_disabled"
-								style="nav-up: #joystick_deadzone_input; nav-down: #autosave_disabled"
+                            <input
+                                type="radio"
+                                data-event-blur="set_cur_config_index(-1)"
+                                data-event-focus="set_cur_config_index(5)"
+                                name="background_input_mode"
+                                data-checked="background_input_mode"
+                                value="Off"
+                                id="bg_input_disabled"
+                                style="nav-up: #joystick_deadzone_input; nav-down: #autosave_disabled"
                             />
-							<label class="config-option__tab-label" for="bg_input_disabled">Off</label>
-						</div>
-					</div>
+                            <label class="config-option__tab-label" for="bg_input_disabled">Off</label>
+                        </div>
+                    </div>
 
-					<!-- autosave -->
-					<div class="config-option" data-event-mouseover="set_cur_config_index(6)">
-						<label class="config-option__title">Autosaving</label>
-						<div class="config-option__list">
-							<input
-								type="radio"
-								data-event-blur="set_cur_config_index(-1)"
-								data-event-focus="set_cur_config_index(6)"
-								name="autosave_mode"
-								data-checked="autosave_mode"
-								value="On"
-								id="autosave_enabled"
-								style="nav-up: #bg_input_enabled; nav-down: #camera_inversion_none"
+                    <!-- autosave -->
+                    <div class="config-option" data-event-mouseover="set_cur_config_index(6)">
+                        <label class="config-option__title">Autosaving</label>
+                        <div class="config-option__list">
+                            <input
+                                type="radio"
+                                data-event-blur="set_cur_config_index(-1)"
+                                data-event-focus="set_cur_config_index(6)"
+                                name="autosave_mode"
+                                data-checked="autosave_mode"
+                                value="On"
+                                id="autosave_enabled"
+                                style="nav-up: #bg_input_enabled; nav-down: #camera_inversion_none"
                             />
-							<label class="config-option__tab-label" for="autosave_enabled">On</label>
+                            <label class="config-option__tab-label" for="autosave_enabled">On</label>
 
-							<input
-								type="radio"
-								data-event-blur="set_cur_config_index(-1)"
-								data-event-focus="set_cur_config_index(6)"
-								name="autosave_mode"
-								data-checked="autosave_mode"
-								value="Off"
-								id="autosave_disabled"
-								style="nav-up: #bg_input_disabled; nav-down: #camera_inversion_x"
+                            <input
+                                type="radio"
+                                data-event-blur="set_cur_config_index(-1)"
+                                data-event-focus="set_cur_config_index(6)"
+                                name="autosave_mode"
+                                data-checked="autosave_mode"
+                                value="Off"
+                                id="autosave_disabled"
+                                style="nav-up: #bg_input_disabled; nav-down: #camera_inversion_x"
                             />
-							<label class="config-option__tab-label" for="autosave_disabled">Off</label>
-						</div>
-					</div>
+                            <label class="config-option__tab-label" for="autosave_disabled">Off</label>
+                        </div>
+                    </div>
 
-					<!-- camera inversion -->
-					<div class="config-option" data-event-mouseover="set_cur_config_index(7)">
-						<label class="config-option__title">Aiming Camera Mode</label>
-						<div class="config-option__list">
-							<input
-								type="radio"
-								data-event-blur="set_cur_config_index(-1)"
-								data-event-focus="set_cur_config_index(7)"
-								name="camera_invert_mode"
-								data-checked="camera_invert_mode"
-								value="InvertNone"
-								id="camera_inversion_none"
-								style="nav-up: #autosave_enabled; nav-down: #analog_cam_enabled"
+                    <!-- camera inversion -->
+                    <div class="config-option" data-event-mouseover="set_cur_config_index(7)">
+                        <label class="config-option__title">Aiming Camera Mode</label>
+                        <div class="config-option__list">
+                            <input
+                                type="radio"
+                                data-event-blur="set_cur_config_index(-1)"
+                                data-event-focus="set_cur_config_index(7)"
+                                name="camera_invert_mode"
+                                data-checked="camera_invert_mode"
+                                value="InvertNone"
+                                id="camera_inversion_none"
+                                style="nav-up: #autosave_enabled; nav-down: #analog_cam_enabled"
                             />
-							<label class="config-option__tab-label" for="camera_inversion_none">None</label>
+                            <label class="config-option__tab-label" for="camera_inversion_none">None</label>
 
-							<input
-								type="radio"
-								data-event-blur="set_cur_config_index(-1)"
-								data-event-focus="set_cur_config_index(7)"
-								name="camera_invert_mode"
-								data-checked="camera_invert_mode"
-								value="InvertX"
-								id="camera_inversion_x"
-								style="nav-up: #autosave_disabled; nav-down: #analog_cam_disabled"
+                            <input
+                                type="radio"
+                                data-event-blur="set_cur_config_index(-1)"
+                                data-event-focus="set_cur_config_index(7)"
+                                name="camera_invert_mode"
+                                data-checked="camera_invert_mode"
+                                value="InvertX"
+                                id="camera_inversion_x"
+                                style="nav-up: #autosave_disabled; nav-down: #analog_cam_disabled"
                             />
-							<label class="config-option__tab-label" for="camera_inversion_x">Invert X</label>
+                            <label class="config-option__tab-label" for="camera_inversion_x">Invert X</label>
 
-							<input
-								type="radio"
-								data-event-blur="set_cur_config_index(-1)"
-								data-event-focus="set_cur_config_index(7)"
-								name="camera_invert_mode"
-								data-checked="camera_invert_mode"
-								value="InvertY"
-								id="camera_inversion_y"
-								style="nav-up: #autosave_disabled; nav-down: #analog_cam_disabled"
+                            <input
+                                type="radio"
+                                data-event-blur="set_cur_config_index(-1)"
+                                data-event-focus="set_cur_config_index(7)"
+                                name="camera_invert_mode"
+                                data-checked="camera_invert_mode"
+                                value="InvertY"
+                                id="camera_inversion_y"
+                                style="nav-up: #autosave_disabled; nav-down: #analog_cam_disabled"
                             />
-							<label class="config-option__tab-label" for="camera_inversion_y">Invert Y</label>
+                            <label class="config-option__tab-label" for="camera_inversion_y">Invert Y</label>
 
-							<input
-								type="radio"
-								data-event-blur="set_cur_config_index(-1)"
-								data-event-focus="set_cur_config_index(7)"
-								name="camera_invert_mode"
-								data-checked="camera_invert_mode"
-								value="InvertBoth"
-								id="camera_inversion_both"
-								style="nav-up: #autosave_disabled; nav-down: #analog_cam_disabled"
+                            <input
+                                type="radio"
+                                data-event-blur="set_cur_config_index(-1)"
+                                data-event-focus="set_cur_config_index(7)"
+                                name="camera_invert_mode"
+                                data-checked="camera_invert_mode"
+                                value="InvertBoth"
+                                id="camera_inversion_both"
+                                style="nav-up: #autosave_disabled; nav-down: #analog_cam_disabled"
                             />
-							<label class="config-option__tab-label" for="camera_inversion_both">Invert Both</label>
-						</div>
-					</div>
+                            <label class="config-option__tab-label" for="camera_inversion_both">Invert Both</label>
+                        </div>
+                    </div>
 
-					<!-- analog camera -->
-					<div class="config-option" data-event-mouseover="set_cur_config_index(8)">
-						<label class="config-option__title">Analog Camera</label>
-						<div class="config-option__list">
-							<input
-								type="radio"
-								data-event-blur="set_cur_config_index(-1)"
-								data-event-focus="set_cur_config_index(8)"
-								name="analog_cam_mode"
-								data-checked="analog_cam_mode"
-								value="On"
-								id="analog_cam_enabled"
-								style="nav-up: #camera_inversion_none; nav-down: #analog_camera_inversion_none"
+                    <!-- analog camera -->
+                    <div class="config-option" data-event-mouseover="set_cur_config_index(8)">
+                        <label class="config-option__title">Analog Camera</label>
+                        <div class="config-option__list">
+                            <input
+                                type="radio"
+                                data-event-blur="set_cur_config_index(-1)"
+                                data-event-focus="set_cur_config_index(8)"
+                                name="analog_cam_mode"
+                                data-checked="analog_cam_mode"
+                                value="On"
+                                id="analog_cam_enabled"
+                                style="nav-up: #camera_inversion_none; nav-down: #analog_camera_inversion_none"
                             />
-							<label class="config-option__tab-label" for="analog_cam_enabled">On</label>
+                            <label class="config-option__tab-label" for="analog_cam_enabled">On</label>
 
-							<input
-								type="radio"
-								data-event-blur="set_cur_config_index(-1)"
-								data-event-focus="set_cur_config_index(8)"
-								name="analog_cam_mode"
-								data-checked="analog_cam_mode"
-								value="Off"
-								id="analog_cam_disabled"
-								style="nav-up: #camera_inversion_x; nav-down: #analog_camera_inversion_x"
+                            <input
+                                type="radio"
+                                data-event-blur="set_cur_config_index(-1)"
+                                data-event-focus="set_cur_config_index(8)"
+                                name="analog_cam_mode"
+                                data-checked="analog_cam_mode"
+                                value="Off"
+                                id="analog_cam_disabled"
+                                style="nav-up: #camera_inversion_x; nav-down: #analog_camera_inversion_x"
                             />
-							<label class="config-option__tab-label" for="analog_cam_disabled">Off</label>
-						</div>
-					</div>
+                            <label class="config-option__tab-label" for="analog_cam_disabled">Off</label>
+                        </div>
+                    </div>
 
-					<!-- analog camera inversion -->
-					<div class="config-option" data-event-mouseover="set_cur_config_index(9)">
-						<label class="config-option__title">Analog Camera Mode</label>
-						<div class="config-option__list">
-							<input
-								type="radio"
-								data-event-blur="set_cur_config_index(-1)"
-								data-event-focus="set_cur_config_index(9)"
-								name="analog_camera_invert_mode"
-								data-checked="analog_camera_invert_mode"
-								value="InvertNone"
-								id="analog_camera_inversion_none"
-								style="nav-up: #analog_cam_enabled; nav-down: #special_item_hud_enabled"
+                    <!-- analog camera inversion -->
+                    <div class="config-option" data-event-mouseover="set_cur_config_index(9)">
+                        <label class="config-option__title">Analog Camera Mode</label>
+                        <div class="config-option__list">
+                            <input
+                                type="radio"
+                                data-event-blur="set_cur_config_index(-1)"
+                                data-event-focus="set_cur_config_index(9)"
+                                name="analog_camera_invert_mode"
+                                data-checked="analog_camera_invert_mode"
+                                value="InvertNone"
+                                id="analog_camera_inversion_none"
+                                style="nav-up: #analog_cam_enabled; nav-down: #special_item_hud_enabled"
                             />
-							<label class="config-option__tab-label" for="analog_camera_inversion_none">None</label>
+                            <label class="config-option__tab-label" for="analog_camera_inversion_none">None</label>
 
-							<input
-								type="radio"
-								data-event-blur="set_cur_config_index(-1)"
-								data-event-focus="set_cur_config_index(9)"
-								name="analog_camera_invert_mode"
-								data-checked="analog_camera_invert_mode"
-								value="InvertX"
-								id="analog_camera_inversion_x"
-								style="nav-up: #analog_cam_disabled; nav-down: #special_item_hud_enabled"
+                            <input
+                                type="radio"
+                                data-event-blur="set_cur_config_index(-1)"
+                                data-event-focus="set_cur_config_index(9)"
+                                name="analog_camera_invert_mode"
+                                data-checked="analog_camera_invert_mode"
+                                value="InvertX"
+                                id="analog_camera_inversion_x"
+                                style="nav-up: #analog_cam_disabled; nav-down: #special_item_hud_enabled"
                             />
-							<label class="config-option__tab-label" for="analog_camera_inversion_x">Invert X</label>
+                            <label class="config-option__tab-label" for="analog_camera_inversion_x">Invert X</label>
 
-							<input
-								type="radio"
-								data-event-blur="set_cur_config_index(-1)"
-								data-event-focus="set_cur_config_index(9)"
-								name="analog_camera_invert_mode"
-								data-checked="analog_camera_invert_mode"
-								value="InvertY"
-								id="analog_camera_inversion_y"
-								style="nav-up: #analog_cam_disabled; nav-down: #special_item_hud_disabled"
+                            <input
+                                type="radio"
+                                data-event-blur="set_cur_config_index(-1)"
+                                data-event-focus="set_cur_config_index(9)"
+                                name="analog_camera_invert_mode"
+                                data-checked="analog_camera_invert_mode"
+                                value="InvertY"
+                                id="analog_camera_inversion_y"
+                                style="nav-up: #analog_cam_disabled; nav-down: #special_item_hud_disabled"
                             />
-							<label class="config-option__tab-label" for="analog_camera_inversion_y">Invert Y</label>
+                            <label class="config-option__tab-label" for="analog_camera_inversion_y">Invert Y</label>
 
-							<input
-								type="radio"
-								data-event-blur="set_cur_config_index(-1)"
-								data-event-focus="set_cur_config_index(9)"
-								name="analog_camera_invert_mode"
-								data-checked="analog_camera_invert_mode"
-								value="InvertBoth"
-								id="analog_camera_inversion_both"
-								style="nav-up: #analog_cam_disabled; nav-down: #special_item_hud_disabled"
+                            <input
+                                type="radio"
+                                data-event-blur="set_cur_config_index(-1)"
+                                data-event-focus="set_cur_config_index(9)"
+                                name="analog_camera_invert_mode"
+                                data-checked="analog_camera_invert_mode"
+                                value="InvertBoth"
+                                id="analog_camera_inversion_both"
+                                style="nav-up: #analog_cam_disabled; nav-down: #special_item_hud_disabled"
                             />
-							<label class="config-option__tab-label" for="analog_camera_inversion_both">Invert Both</label>
-						</div>
-					</div>
+                            <label class="config-option__tab-label" for="analog_camera_inversion_both">Invert Both</label>
+                        </div>
+                    </div>
 
-					<!-- special item hud -->
-					<div class="config-option" data-event-mouseover="set_cur_config_index(10)">
-						<label class="config-option__title">Special Item HUD</label>
-						<div class="config-option__list">
-							<input
-								type="radio"
-								data-event-blur="set_cur_config_index(-1)"
-								data-event-focus="set_cur_config_index(10)"
-								name="special_item_hud_mode"
-								data-checked="special_item_hud_mode"
-								value="On"
-								id="special_item_hud_enabled"
-								style="nav-up: #analog_camera_inversion_none;"
+                    <!-- special item hud -->
+                    <div class="config-option" data-event-mouseover="set_cur_config_index(10)">
+                        <label class="config-option__title">Special Item HUD</label>
+                        <div class="config-option__list">
+                            <input
+                                type="radio"
+                                data-event-blur="set_cur_config_index(-1)"
+                                data-event-focus="set_cur_config_index(10)"
+                                name="special_item_hud_mode"
+                                data-checked="special_item_hud_mode"
+                                value="On"
+                                id="special_item_hud_enabled"
+                                style="nav-up: #analog_camera_inversion_none;"
                             />
-							<label class="config-option__tab-label" for="special_item_hud_enabled">On</label>
+                            <label class="config-option__tab-label" for="special_item_hud_enabled">On</label>
 
-							<input
-								type="radio"
-								data-event-blur="set_cur_config_index(-1)"
-								data-event-focus="set_cur_config_index(10)"
-								name="special_item_hud_mode"
-								data-checked="special_item_hud_mode"
-								value="Off"
-								id="special_item_hud_disabled"
-								style="nav-up: #analog_camera_inversion_x;"
+                            <input
+                                type="radio"
+                                data-event-blur="set_cur_config_index(-1)"
+                                data-event-focus="set_cur_config_index(10)"
+                                name="special_item_hud_mode"
+                                data-checked="special_item_hud_mode"
+                                value="Off"
+                                id="special_item_hud_disabled"
+                                style="nav-up: #analog_camera_inversion_x;"
                             />
-							<label class="config-option__tab-label" for="special_item_hud_disabled">Off</label>
-						</div>
-					</div>
-				</div>
-				<!-- Descriptions -->
-				<div class="config__wrapper">
-					<p data-if="cur_config_index == 0">
-						Controls how targeting enemies and objects works. <b>Switch</b> will start or stop targeting each time the target button is pressed. <b>Hold</b> will start when the target button is pressed and stop when the button is released.
-					</p>
-					<p data-if="cur_config_index == 1">
-						Controls the strength of rumble when using a controller that supports it. <b>Setting this to zero will disable rumble.</b>
-					</p>
-					<p data-if="cur_config_index == 2">
-						Controls the sensitivity of gyro aiming when using items in first person for controllers that support it. <b>Setting this to zero will disable gyro.</b>
-						<br />
-						<br />
-						<b>Note: To recalibrate controller gyro, set the controller down on a still, flat surface for 5 seconds.</b>
-					</p>
-					<p data-if="cur_config_index == 3">
-						Controls the sensitivity of mouse aiming when using items in first person. <b>Setting this to zero will disable mouse aiming.</b>
-						<br />
-						<br />
-						<b>Note: This option does not allow mouse buttons to activate items. Mouse aiming is intended to be used with inputs that are mapped to mouse movement, such as gyro on Steam Deck.</b>
-					</p>
-					<p data-if="cur_config_index == 4">
-						Applies a deadzone to joystick inputs.
-					</p>
-					<p data-if="cur_config_index == 5">
-						Allows the game to read controller input when out of focus.
-						<br/>
-						<b>This setting does not affect keyboard input.</b>
-					</p>
-					<p data-if="cur_config_index == 6">
-						Turns on autosaving and prevents owl saves from being deleted on load. Autosaves act as owl saves and take up the same slot as they do.
-						<br/>
-						<br/>
-						Loading an autosave will place you in Clock Town or at the entrance of the current dungeon if you were in one.
-						<br/>
-						<br/>
-						<b>If autosaving is disabled, existing autosaves will be deleted when loaded.</b>
-					</p>
-					<p data-if="cur_config_index == 7">
-						Inverts the camera controls for first-person aiming. <b>Invert Y</b> is the default and matches the original game.
-					</p>
-					<p data-if="cur_config_index == 8">
-						Enables an analog "free" camera similar to later entries in the series that's mapped to the right analog stick on the controller.
-						<br/>
-						<br/>
-						When you move the right stick, the camera will enter free mode and stop centering behind Link. Press the <b>Target</b> button at any time to go back into the normal camera mode. The camera will also return to normal mode after a cutscene plays or when you move between areas.
-						<br/>
-						<br/>
-						This option also enables right stick control while looking and aiming.
-					</p>
-					<p data-if="cur_config_index == 9">
-						Inverts the camera controls for the analog camera if it's enabled. <b>None</b> is the default.
-					</p>
-					<p data-if="cur_config_index == 10">
-						Enables visibility of the special item HUD. Affects visibility only, functionality can be modified in the <b>Controls</b> setting tab. <b>On</b> is the default.
-					</p>
-				</div>
-			</div>
-		</form>
-	</body>
+                            <label class="config-option__tab-label" for="special_item_hud_disabled">Off</label>
+                        </div>
+                    </div>
+                </div>
+                <!-- Descriptions -->
+                <div class="config__wrapper">
+                    <p data-if="cur_config_index == 0">
+                        Controls how targeting enemies and objects works. <b>Switch</b> will start or stop targeting each time the target button is pressed. <b>Hold</b> will start when the target button is pressed and stop when the button is released.
+                    </p>
+                    <p data-if="cur_config_index == 1">
+                        Controls the strength of rumble when using a controller that supports it. <b>Setting this to zero will disable rumble.</b>
+                    </p>
+                    <p data-if="cur_config_index == 2">
+                        Controls the sensitivity of gyro aiming when using items in first person for controllers that support it. <b>Setting this to zero will disable gyro.</b>
+                        <br />
+                        <br />
+                        <b>Note: To recalibrate controller gyro, set the controller down on a still, flat surface for 5 seconds.</b>
+                    </p>
+                    <p data-if="cur_config_index == 3">
+                        Controls the sensitivity of mouse aiming when using items in first person. <b>Setting this to zero will disable mouse aiming.</b>
+                        <br />
+                        <br />
+                        <b>Note: This option does not allow mouse buttons to activate items. Mouse aiming is intended to be used with inputs that are mapped to mouse movement, such as gyro on Steam Deck.</b>
+                    </p>
+                    <p data-if="cur_config_index == 4">
+                        Applies a deadzone to joystick inputs.
+                    </p>
+                    <p data-if="cur_config_index == 5">
+                        Allows the game to read controller input when out of focus.
+                        <br/>
+                        <b>This setting does not affect keyboard input.</b>
+                    </p>
+                    <p data-if="cur_config_index == 6">
+                        Turns on autosaving and prevents owl saves from being deleted on load. Autosaves act as owl saves and take up the same slot as they do.
+                        <br/>
+                        <br/>
+                        Loading an autosave will place you in Clock Town or at the entrance of the current dungeon if you were in one.
+                        <br/>
+                        <br/>
+                        <b>If autosaving is disabled, existing autosaves will be deleted when loaded.</b>
+                    </p>
+                    <p data-if="cur_config_index == 7">
+                        Inverts the camera controls for first-person aiming. <b>Invert Y</b> is the default and matches the original game.
+                    </p>
+                    <p data-if="cur_config_index == 8">
+                        Enables an analog "free" camera similar to later entries in the series that's mapped to the right analog stick on the controller.
+                        <br/>
+                        <br/>
+                        When you move the right stick, the camera will enter free mode and stop centering behind Link. Press the <b>Target</b> button at any time to go back into the normal camera mode. The camera will also return to normal mode after a cutscene plays or when you move between areas.
+                        <br/>
+                        <br/>
+                        This option also enables right stick control while looking and aiming.
+                    </p>
+                    <p data-if="cur_config_index == 9">
+                        Inverts the camera controls for the analog camera if it's enabled. <b>None</b> is the default.
+                    </p>
+                    <p data-if="cur_config_index == 10">
+                        Enables visibility of the special item HUD. Affects visibility only, functionality can be modified in the <b>Controls</b> setting tab. <b>On</b> is the default.
+                    </p>
+                </div>
+            </div>
+        </form>
+    </body>
 </template>

--- a/assets/config_menu/general.rml
+++ b/assets/config_menu/general.rml
@@ -1,369 +1,402 @@
 <template name="config-menu__general">
-    <head>
-    </head>
-    <body>
-        <form class="config__form" id="conf-general__form">
-            <div class="config__hz-wrapper" id="conf-general__hz-wrapper">
-                <!-- Options -->
-                <div class="config__wrapper" data-event-mouseout="set_cur_config_index(-1)" id="conf-general__wrapper">
-                    <!-- targeting mode -->
-                    <div class="config-option" data-event-mouseover="set_cur_config_index(0)" id="conf-general__Targeting-Mode">
-                        <label class="config-option__title">Targeting Mode</label>
-                        <div class="config-option__list">
-                            <input
-                                type="radio"
-                                data-event-blur="set_cur_config_index(-1)"
-                                data-event-focus="set_cur_config_index(0)"
-                                name="targeting_mode"
-                                data-checked="targeting_mode"
-                                value="Switch"
-                                id="tm_switch"
-                                style="nav-up: #tab_general; nav-down: #rumble_strength_input"
+	<head>
+	</head>
+	<body>
+		<form class="config__form" id="conf-general__form">
+			<div class="config__hz-wrapper" id="conf-general__hz-wrapper">
+				<!-- Options -->
+				<div class="config__wrapper" data-event-mouseout="set_cur_config_index(-1)" id="conf-general__wrapper" style="overflow:auto;max-height:100%">
+					<!-- targeting mode -->
+					<div class="config-option" data-event-mouseover="set_cur_config_index(0)" id="conf-general__Targeting-Mode">
+						<label class="config-option__title">Targeting Mode</label>
+						<div class="config-option__list">
+							<input
+								type="radio"
+								data-event-blur="set_cur_config_index(-1)"
+								data-event-focus="set_cur_config_index(0)"
+								name="targeting_mode"
+								data-checked="targeting_mode"
+								value="Switch"
+								id="tm_switch"
+								style="nav-up: #tab_general; nav-down: #rumble_strength_input"
                             />
-                            <label class="config-option__tab-label" for="tm_switch">Switch</label>
+							<label class="config-option__tab-label" for="tm_switch">Switch</label>
 
-                            <input
-                                type="radio"
-                                data-event-blur="set_cur_config_index(-1)"
-                                data-event-focus="set_cur_config_index(0)"
-                                name="targeting_mode"
-                                data-checked="targeting_mode"
-                                value="Hold"
-                                id="tm_hold"
-                                style="nav-up: #tab_general; nav-down: #rumble_strength_input"
+							<input
+								type="radio"
+								data-event-blur="set_cur_config_index(-1)"
+								data-event-focus="set_cur_config_index(0)"
+								name="targeting_mode"
+								data-checked="targeting_mode"
+								value="Hold"
+								id="tm_hold"
+								style="nav-up: #tab_general; nav-down: #rumble_strength_input"
                             />
-                            <label class="config-option__tab-label" for="tm_hold">Hold</label>
-                        </div>
-                    </div>
+							<label class="config-option__tab-label" for="tm_hold">Hold</label>
+						</div>
+					</div>
 
-                    <!-- rumble strength -->
-                    <div class="config-option" data-event-mouseover="set_cur_config_index(1)">
-                        <label class="config-option__title">Rumble Strength</label>
-                        <div class="config-option__range-wrapper config-option__list">
-                            <label class="config-option__range-label">{{rumble_strength}}%</label>
-                            <input
-                                class="nav-vert"
-                                data-event-blur="set_cur_config_index(-1)"
-                                data-event-focus="set_cur_config_index(1)"
-                                id="rumble_strength_input"
-                                type="range"
-                                min="0"
-                                max="100"
-                                style="flex: 1; margin: 0dp;"
-                                data-value="rumble_strength"
+					<!-- rumble strength -->
+					<div class="config-option" data-event-mouseover="set_cur_config_index(1)">
+						<label class="config-option__title">Rumble Strength</label>
+						<div class="config-option__range-wrapper config-option__list">
+							<label class="config-option__range-label">{{rumble_strength}}%</label>
+							<input
+								class="nav-vert"
+								data-event-blur="set_cur_config_index(-1)"
+								data-event-focus="set_cur_config_index(1)"
+								id="rumble_strength_input"
+								type="range"
+								min="0"
+								max="100"
+								style="flex: 1; margin: 0dp;"
+								data-value="rumble_strength"
                             />
-                        </div>
-                    </div>
+						</div>
+					</div>
 
-                    <!-- gyro sensitivity -->
-                    <div class="config-option" data-event-mouseover="set_cur_config_index(2)">
-                        <label class="config-option__title">Gyro Sensitivity</label>
-                        <div class="config-option__range-wrapper config-option__list">
-                            <label class="config-option__range-label">{{gyro_sensitivity}}%</label>
-                            <input
-                                class="nav-vert"
-                                data-event-blur="set_cur_config_index(-1)"
-                                data-event-focus="set_cur_config_index(2)"
-                                id="gyro_sensitivity_input"
-                                type="range"
-                                min="0"
-                                max="100"
-                                style="flex: 1; margin: 0dp;"
-                                data-value="gyro_sensitivity"
+					<!-- gyro sensitivity -->
+					<div class="config-option" data-event-mouseover="set_cur_config_index(2)">
+						<label class="config-option__title">Gyro Sensitivity</label>
+						<div class="config-option__range-wrapper config-option__list">
+							<label class="config-option__range-label">{{gyro_sensitivity}}%</label>
+							<input
+								class="nav-vert"
+								data-event-blur="set_cur_config_index(-1)"
+								data-event-focus="set_cur_config_index(2)"
+								id="gyro_sensitivity_input"
+								type="range"
+								min="0"
+								max="100"
+								style="flex: 1; margin: 0dp;"
+								data-value="gyro_sensitivity"
                             />
-                        </div>
-                    </div>
+						</div>
+					</div>
 
-                    <!-- mouse sensitivity -->
-                    <div class="config-option" data-event-mouseover="set_cur_config_index(3)">
-                        <label class="config-option__title">Mouse Sensitivity</label>
-                        <div class="config-option__range-wrapper config-option__list">
-                            <label class="config-option__range-label">{{mouse_sensitivity}}%</label>
-                            <input
-                                class="nav-vert"
-                                data-event-blur="set_cur_config_index(-1)"
-                                data-event-focus="set_cur_config_index(3)"
-                                id="mouse_sensitivity_input"
-                                type="range"
-                                min="0"
-                                max="100"
-                                style="flex: 1; margin: 0dp;"
-                                data-value="mouse_sensitivity"
+					<!-- mouse sensitivity -->
+					<div class="config-option" data-event-mouseover="set_cur_config_index(3)">
+						<label class="config-option__title">Mouse Sensitivity</label>
+						<div class="config-option__range-wrapper config-option__list">
+							<label class="config-option__range-label">{{mouse_sensitivity}}%</label>
+							<input
+								class="nav-vert"
+								data-event-blur="set_cur_config_index(-1)"
+								data-event-focus="set_cur_config_index(3)"
+								id="mouse_sensitivity_input"
+								type="range"
+								min="0"
+								max="100"
+								style="flex: 1; margin: 0dp;"
+								data-value="mouse_sensitivity"
                             />
-                        </div>
-                    </div>
-                    
-                    <!-- joystick deadzone -->
-                    <div class="config-option" data-event-mouseover="set_cur_config_index(4)">
-                        <label class="config-option__title">Joystick Deadzone</label>
-                        <div class="config-option__range-wrapper config-option__list">
-                            <label class="config-option__range-label">{{joystick_deadzone}}%</label>
-                            <input
-                                class="nav-vert"
-                                data-event-blur="set_cur_config_index(-1)"
-                                data-event-focus="set_cur_config_index(4)"
-                                id="joystick_deadzone_input"
-                                type="range"
-                                min="0"
-                                max="100"
-                                style="flex: 1; margin: 0dp; nav-down: #bg_input_enabled"
-                                data-value="joystick_deadzone"
-                            />
-                        </div>
-                    </div>
+						</div>
+					</div>
 
-                    <!-- background input -->
-                    <div class="config-option" data-event-mouseover="set_cur_config_index(5)" id="conf-general__Background-Input">
-                        <label class="config-option__title">Background Input</label>
-                        <div class="config-option__list">
-                            <input
-                                type="radio"
-                                data-event-blur="set_cur_config_index(-1)"
-                                data-event-focus="set_cur_config_index(5)"
-                                name="background_input_mode"
-                                data-checked="background_input_mode"
-                                value="On"
-                                id="bg_input_enabled"
-                                style="nav-up: #joystick_deadzone_input; nav-down: #autosave_enabled"
+					<!-- joystick deadzone -->
+					<div class="config-option" data-event-mouseover="set_cur_config_index(4)">
+						<label class="config-option__title">Joystick Deadzone</label>
+						<div class="config-option__range-wrapper config-option__list">
+							<label class="config-option__range-label">{{joystick_deadzone}}%</label>
+							<input
+								class="nav-vert"
+								data-event-blur="set_cur_config_index(-1)"
+								data-event-focus="set_cur_config_index(4)"
+								id="joystick_deadzone_input"
+								type="range"
+								min="0"
+								max="100"
+								style="flex: 1; margin: 0dp; nav-down: #bg_input_enabled"
+								data-value="joystick_deadzone"
                             />
-                            <label class="config-option__tab-label" for="bg_input_enabled">On</label>
+						</div>
+					</div>
 
-                            <input
-                                type="radio"
-                                data-event-blur="set_cur_config_index(-1)"
-                                data-event-focus="set_cur_config_index(5)"
-                                name="background_input_mode"
-                                data-checked="background_input_mode"
-                                value="Off"
-                                id="bg_input_disabled"
-                                style="nav-up: #joystick_deadzone_input; nav-down: #autosave_disabled"
+					<!-- background input -->
+					<div class="config-option" data-event-mouseover="set_cur_config_index(5)" id="conf-general__Background-Input">
+						<label class="config-option__title">Background Input</label>
+						<div class="config-option__list">
+							<input
+								type="radio"
+								data-event-blur="set_cur_config_index(-1)"
+								data-event-focus="set_cur_config_index(5)"
+								name="background_input_mode"
+								data-checked="background_input_mode"
+								value="On"
+								id="bg_input_enabled"
+								style="nav-up: #joystick_deadzone_input; nav-down: #autosave_enabled"
                             />
-                            <label class="config-option__tab-label" for="bg_input_disabled">Off</label>
-                        </div>
-                    </div>
+							<label class="config-option__tab-label" for="bg_input_enabled">On</label>
 
-                    <!-- autosave -->
-                    <div class="config-option" data-event-mouseover="set_cur_config_index(6)">
-                        <label class="config-option__title">Autosaving</label>
-                        <div class="config-option__list">
-                            <input
-                                type="radio"
-                                data-event-blur="set_cur_config_index(-1)"
-                                data-event-focus="set_cur_config_index(6)"
-                                name="autosave_mode"
-                                data-checked="autosave_mode"
-                                value="On"
-                                id="autosave_enabled"
-                                style="nav-up: #bg_input_enabled; nav-down: #camera_inversion_none"
+							<input
+								type="radio"
+								data-event-blur="set_cur_config_index(-1)"
+								data-event-focus="set_cur_config_index(5)"
+								name="background_input_mode"
+								data-checked="background_input_mode"
+								value="Off"
+								id="bg_input_disabled"
+								style="nav-up: #joystick_deadzone_input; nav-down: #autosave_disabled"
                             />
-                            <label class="config-option__tab-label" for="autosave_enabled">On</label>
+							<label class="config-option__tab-label" for="bg_input_disabled">Off</label>
+						</div>
+					</div>
 
-                            <input
-                                type="radio"
-                                data-event-blur="set_cur_config_index(-1)"
-                                data-event-focus="set_cur_config_index(6)"
-                                name="autosave_mode"
-                                data-checked="autosave_mode"
-                                value="Off"
-                                id="autosave_disabled"
-                                style="nav-up: #bg_input_disabled; nav-down: #camera_inversion_x"
+					<!-- autosave -->
+					<div class="config-option" data-event-mouseover="set_cur_config_index(6)">
+						<label class="config-option__title">Autosaving</label>
+						<div class="config-option__list">
+							<input
+								type="radio"
+								data-event-blur="set_cur_config_index(-1)"
+								data-event-focus="set_cur_config_index(6)"
+								name="autosave_mode"
+								data-checked="autosave_mode"
+								value="On"
+								id="autosave_enabled"
+								style="nav-up: #bg_input_enabled; nav-down: #camera_inversion_none"
                             />
-                            <label class="config-option__tab-label" for="autosave_disabled">Off</label>
-                        </div>
-                    </div>
-                    
-                    <!-- camera inversion -->
-                    <div class="config-option" data-event-mouseover="set_cur_config_index(7)">
-                        <label class="config-option__title">Aiming Camera Mode</label>
-                        <div class="config-option__list">
-                            <input
-                                type="radio"
-                                data-event-blur="set_cur_config_index(-1)"
-                                data-event-focus="set_cur_config_index(7)"
-                                name="camera_invert_mode"
-                                data-checked="camera_invert_mode"
-                                value="InvertNone"
-                                id="camera_inversion_none"
-                                style="nav-up: #autosave_enabled; nav-down: #analog_cam_enabled"
-                            />
-                            <label class="config-option__tab-label" for="camera_inversion_none">None</label>
+							<label class="config-option__tab-label" for="autosave_enabled">On</label>
 
-                            <input
-                                type="radio"
-                                data-event-blur="set_cur_config_index(-1)"
-                                data-event-focus="set_cur_config_index(7)"
-                                name="camera_invert_mode"
-                                data-checked="camera_invert_mode"
-                                value="InvertX"
-                                id="camera_inversion_x"
-                                style="nav-up: #autosave_disabled; nav-down: #analog_cam_disabled"
+							<input
+								type="radio"
+								data-event-blur="set_cur_config_index(-1)"
+								data-event-focus="set_cur_config_index(6)"
+								name="autosave_mode"
+								data-checked="autosave_mode"
+								value="Off"
+								id="autosave_disabled"
+								style="nav-up: #bg_input_disabled; nav-down: #camera_inversion_x"
                             />
-                            <label class="config-option__tab-label" for="camera_inversion_x">Invert X</label>
+							<label class="config-option__tab-label" for="autosave_disabled">Off</label>
+						</div>
+					</div>
 
-                            <input
-                                type="radio"
-                                data-event-blur="set_cur_config_index(-1)"
-                                data-event-focus="set_cur_config_index(7)"
-                                name="camera_invert_mode"
-                                data-checked="camera_invert_mode"
-                                value="InvertY"
-                                id="camera_inversion_y"
-                                style="nav-up: #autosave_disabled; nav-down: #analog_cam_disabled"
+					<!-- camera inversion -->
+					<div class="config-option" data-event-mouseover="set_cur_config_index(7)">
+						<label class="config-option__title">Aiming Camera Mode</label>
+						<div class="config-option__list">
+							<input
+								type="radio"
+								data-event-blur="set_cur_config_index(-1)"
+								data-event-focus="set_cur_config_index(7)"
+								name="camera_invert_mode"
+								data-checked="camera_invert_mode"
+								value="InvertNone"
+								id="camera_inversion_none"
+								style="nav-up: #autosave_enabled; nav-down: #analog_cam_enabled"
                             />
-                            <label class="config-option__tab-label" for="camera_inversion_y">Invert Y</label>
+							<label class="config-option__tab-label" for="camera_inversion_none">None</label>
 
-                            <input
-                                type="radio"
-                                data-event-blur="set_cur_config_index(-1)"
-                                data-event-focus="set_cur_config_index(7)"
-                                name="camera_invert_mode"
-                                data-checked="camera_invert_mode"
-                                value="InvertBoth"
-                                id="camera_inversion_both"
-                                style="nav-up: #autosave_disabled; nav-down: #analog_cam_disabled"
+							<input
+								type="radio"
+								data-event-blur="set_cur_config_index(-1)"
+								data-event-focus="set_cur_config_index(7)"
+								name="camera_invert_mode"
+								data-checked="camera_invert_mode"
+								value="InvertX"
+								id="camera_inversion_x"
+								style="nav-up: #autosave_disabled; nav-down: #analog_cam_disabled"
                             />
-                            <label class="config-option__tab-label" for="camera_inversion_both">Invert Both</label>
-                        </div>
-                    </div>
-                    
-                    <!-- analog camera -->
-                    <div class="config-option" data-event-mouseover="set_cur_config_index(8)">
-                        <label class="config-option__title">Analog Camera</label>
-                        <div class="config-option__list">
-                            <input
-                                type="radio"
-                                data-event-blur="set_cur_config_index(-1)"
-                                data-event-focus="set_cur_config_index(8)"
-                                name="analog_cam_mode"
-                                data-checked="analog_cam_mode"
-                                value="On"
-                                id="analog_cam_enabled"
-                                style="nav-up: #camera_inversion_none; nav-down: #analog_camera_inversion_none"
-                            />
-                            <label class="config-option__tab-label" for="analog_cam_enabled">On</label>
+							<label class="config-option__tab-label" for="camera_inversion_x">Invert X</label>
 
-                            <input
-                                type="radio"
-                                data-event-blur="set_cur_config_index(-1)"
-                                data-event-focus="set_cur_config_index(8)"
-                                name="analog_cam_mode"
-                                data-checked="analog_cam_mode"
-                                value="Off"
-                                id="analog_cam_disabled"
-                                style="nav-up: #camera_inversion_x; nav-down: #analog_camera_inversion_x"
+							<input
+								type="radio"
+								data-event-blur="set_cur_config_index(-1)"
+								data-event-focus="set_cur_config_index(7)"
+								name="camera_invert_mode"
+								data-checked="camera_invert_mode"
+								value="InvertY"
+								id="camera_inversion_y"
+								style="nav-up: #autosave_disabled; nav-down: #analog_cam_disabled"
                             />
-                            <label class="config-option__tab-label" for="analog_cam_disabled">Off</label>
-                        </div>
-                    </div>
-                    
-                    <!-- analog camera inversion -->
-                    <div class="config-option" data-event-mouseover="set_cur_config_index(9)">
-                        <label class="config-option__title">Analog Camera Mode</label>
-                        <div class="config-option__list">
-                            <input
-                                type="radio"
-                                data-event-blur="set_cur_config_index(-1)"
-                                data-event-focus="set_cur_config_index(9)"
-                                name="analog_camera_invert_mode"
-                                data-checked="analog_camera_invert_mode"
-                                value="InvertNone"
-                                id="analog_camera_inversion_none"
-                                style="nav-up: #analog_cam_enabled;"
-                            />
-                            <label class="config-option__tab-label" for="analog_camera_inversion_none">None</label>
+							<label class="config-option__tab-label" for="camera_inversion_y">Invert Y</label>
 
-                            <input
-                                type="radio"
-                                data-event-blur="set_cur_config_index(-1)"
-                                data-event-focus="set_cur_config_index(9)"
-                                name="analog_camera_invert_mode"
-                                data-checked="analog_camera_invert_mode"
-                                value="InvertX"
-                                id="analog_camera_inversion_x"
-                                style="nav-up: #analog_cam_disabled;"
+							<input
+								type="radio"
+								data-event-blur="set_cur_config_index(-1)"
+								data-event-focus="set_cur_config_index(7)"
+								name="camera_invert_mode"
+								data-checked="camera_invert_mode"
+								value="InvertBoth"
+								id="camera_inversion_both"
+								style="nav-up: #autosave_disabled; nav-down: #analog_cam_disabled"
                             />
-                            <label class="config-option__tab-label" for="analog_camera_inversion_x">Invert X</label>
+							<label class="config-option__tab-label" for="camera_inversion_both">Invert Both</label>
+						</div>
+					</div>
 
-                            <input
-                                type="radio"
-                                data-event-blur="set_cur_config_index(-1)"
-                                data-event-focus="set_cur_config_index(9)"
-                                name="analog_camera_invert_mode"
-                                data-checked="analog_camera_invert_mode"
-                                value="InvertY"
-                                id="analog_camera_inversion_y"
-                                style="nav-up: #analog_cam_disabled;"
+					<!-- analog camera -->
+					<div class="config-option" data-event-mouseover="set_cur_config_index(8)">
+						<label class="config-option__title">Analog Camera</label>
+						<div class="config-option__list">
+							<input
+								type="radio"
+								data-event-blur="set_cur_config_index(-1)"
+								data-event-focus="set_cur_config_index(8)"
+								name="analog_cam_mode"
+								data-checked="analog_cam_mode"
+								value="On"
+								id="analog_cam_enabled"
+								style="nav-up: #camera_inversion_none; nav-down: #analog_camera_inversion_none"
                             />
-                            <label class="config-option__tab-label" for="analog_camera_inversion_y">Invert Y</label>
+							<label class="config-option__tab-label" for="analog_cam_enabled">On</label>
 
-                            <input
-                                type="radio"
-                                data-event-blur="set_cur_config_index(-1)"
-                                data-event-focus="set_cur_config_index(9)"
-                                name="analog_camera_invert_mode"
-                                data-checked="analog_camera_invert_mode"
-                                value="InvertBoth"
-                                id="analog_camera_inversion_both"
-                                style="nav-up: #analog_cam_disabled;"
+							<input
+								type="radio"
+								data-event-blur="set_cur_config_index(-1)"
+								data-event-focus="set_cur_config_index(8)"
+								name="analog_cam_mode"
+								data-checked="analog_cam_mode"
+								value="Off"
+								id="analog_cam_disabled"
+								style="nav-up: #camera_inversion_x; nav-down: #analog_camera_inversion_x"
                             />
-                            <label class="config-option__tab-label" for="analog_camera_inversion_both">Invert Both</label>
-                        </div>
-                    </div>
-                </div>
-                <!-- Descriptions -->
-                <div class="config__wrapper">
-                    <p data-if="cur_config_index == 0">
-                        Controls how targeting enemies and objects works. <b>Switch</b> will start or stop targeting each time the target button is pressed. <b>Hold</b> will start when the target button is pressed and stop when the button is released. 
-                    </p>
-                    <p data-if="cur_config_index == 1">
-                        Controls the strength of rumble when using a controller that supports it. <b>Setting this to zero will disable rumble.</b>
-                    </p>
-                    <p data-if="cur_config_index == 2">
-                        Controls the sensitivity of gyro aiming when using items in first person for controllers that support it. <b>Setting this to zero will disable gyro.</b>
-                        <br />
-                        <br />
-                        <b>Note: To recalibrate controller gyro, set the controller down on a still, flat surface for 5 seconds.</b>
-                    </p>
-                    <p data-if="cur_config_index == 3">
-                        Controls the sensitivity of mouse aiming when using items in first person. <b>Setting this to zero will disable mouse aiming.</b>
-                        <br />
-                        <br />
-                        <b>Note: This option does not allow mouse buttons to activate items. Mouse aiming is intended to be used with inputs that are mapped to mouse movement, such as gyro on Steam Deck.</b>
-                    </p>
-                    <p data-if="cur_config_index == 4">
-                        Applies a deadzone to joystick inputs.
-                    </p>
-                    <p data-if="cur_config_index == 5">
-                        Allows the game to read controller input when out of focus.
-                        <br/>
-                        <b>This setting does not affect keyboard input.</b>
-                    </p>
-                    <p data-if="cur_config_index == 6">
-                        Turns on autosaving and prevents owl saves from being deleted on load. Autosaves act as owl saves and take up the same slot as they do.
-                        <br/>
-                        <br/>
-                        Loading an autosave will place you in Clock Town or at the entrance of the current dungeon if you were in one.
-                        <br/>
-                        <br/>
-                        <b>If autosaving is disabled, existing autosaves will be deleted when loaded.</b>
-                    </p>
-                    <p data-if="cur_config_index == 7">
-                        Inverts the camera controls for first-person aiming. <b>Invert Y</b> is the default and matches the original game.
-                    </p>
-                    <p data-if="cur_config_index == 8">
-                        Enables an analog "free" camera similar to later entries in the series that's mapped to the right analog stick on the controller.
-                        <br/>
-                        <br/>
-                        When you move the right stick, the camera will enter free mode and stop centering behind Link. Press the <b>Target</b> button at any time to go back into the normal camera mode. The camera will also return to normal mode after a cutscene plays or when you move between areas.
-                        <br/>
-                        <br/>
-                        This option also enables right stick control while looking and aiming.
-                    </p>
-                    <p data-if="cur_config_index == 9">
-                        Inverts the camera controls for the analog camera if it's enabled. <b>None</b> is the default.
-                    </p>
-                </div>
-            </div>
-        </form>
-    </body>
+							<label class="config-option__tab-label" for="analog_cam_disabled">Off</label>
+						</div>
+					</div>
+
+					<!-- analog camera inversion -->
+					<div class="config-option" data-event-mouseover="set_cur_config_index(9)">
+						<label class="config-option__title">Analog Camera Mode</label>
+						<div class="config-option__list">
+							<input
+								type="radio"
+								data-event-blur="set_cur_config_index(-1)"
+								data-event-focus="set_cur_config_index(9)"
+								name="analog_camera_invert_mode"
+								data-checked="analog_camera_invert_mode"
+								value="InvertNone"
+								id="analog_camera_inversion_none"
+								style="nav-up: #analog_cam_enabled; nav-down: #special_item_hud_enabled"
+                            />
+							<label class="config-option__tab-label" for="analog_camera_inversion_none">None</label>
+
+							<input
+								type="radio"
+								data-event-blur="set_cur_config_index(-1)"
+								data-event-focus="set_cur_config_index(9)"
+								name="analog_camera_invert_mode"
+								data-checked="analog_camera_invert_mode"
+								value="InvertX"
+								id="analog_camera_inversion_x"
+								style="nav-up: #analog_cam_disabled; nav-down: #special_item_hud_enabled"
+                            />
+							<label class="config-option__tab-label" for="analog_camera_inversion_x">Invert X</label>
+
+							<input
+								type="radio"
+								data-event-blur="set_cur_config_index(-1)"
+								data-event-focus="set_cur_config_index(9)"
+								name="analog_camera_invert_mode"
+								data-checked="analog_camera_invert_mode"
+								value="InvertY"
+								id="analog_camera_inversion_y"
+								style="nav-up: #analog_cam_disabled; nav-down: #special_item_hud_disabled"
+                            />
+							<label class="config-option__tab-label" for="analog_camera_inversion_y">Invert Y</label>
+
+							<input
+								type="radio"
+								data-event-blur="set_cur_config_index(-1)"
+								data-event-focus="set_cur_config_index(9)"
+								name="analog_camera_invert_mode"
+								data-checked="analog_camera_invert_mode"
+								value="InvertBoth"
+								id="analog_camera_inversion_both"
+								style="nav-up: #analog_cam_disabled; nav-down: #special_item_hud_disabled"
+                            />
+							<label class="config-option__tab-label" for="analog_camera_inversion_both">Invert Both</label>
+						</div>
+					</div>
+
+					<!-- special item hud -->
+					<div class="config-option" data-event-mouseover="set_cur_config_index(10)">
+						<label class="config-option__title">Special Item HUD</label>
+						<div class="config-option__list">
+							<input
+								type="radio"
+								data-event-blur="set_cur_config_index(-1)"
+								data-event-focus="set_cur_config_index(10)"
+								name="special_item_hud_mode"
+								data-checked="special_item_hud_mode"
+								value="On"
+								id="special_item_hud_enabled"
+								style="nav-up: #analog_camera_inversion_none;"
+                            />
+							<label class="config-option__tab-label" for="special_item_hud_enabled">On</label>
+
+							<input
+								type="radio"
+								data-event-blur="set_cur_config_index(-1)"
+								data-event-focus="set_cur_config_index(10)"
+								name="special_item_hud_mode"
+								data-checked="special_item_hud_mode"
+								value="Off"
+								id="special_item_hud_disabled"
+								style="nav-up: #analog_camera_inversion_x;"
+                            />
+							<label class="config-option__tab-label" for="special_item_hud_disabled">Off</label>
+						</div>
+					</div>
+				</div>
+				<!-- Descriptions -->
+				<div class="config__wrapper">
+					<p data-if="cur_config_index == 0">
+						Controls how targeting enemies and objects works. <b>Switch</b> will start or stop targeting each time the target button is pressed. <b>Hold</b> will start when the target button is pressed and stop when the button is released.
+					</p>
+					<p data-if="cur_config_index == 1">
+						Controls the strength of rumble when using a controller that supports it. <b>Setting this to zero will disable rumble.</b>
+					</p>
+					<p data-if="cur_config_index == 2">
+						Controls the sensitivity of gyro aiming when using items in first person for controllers that support it. <b>Setting this to zero will disable gyro.</b>
+						<br />
+						<br />
+						<b>Note: To recalibrate controller gyro, set the controller down on a still, flat surface for 5 seconds.</b>
+					</p>
+					<p data-if="cur_config_index == 3">
+						Controls the sensitivity of mouse aiming when using items in first person. <b>Setting this to zero will disable mouse aiming.</b>
+						<br />
+						<br />
+						<b>Note: This option does not allow mouse buttons to activate items. Mouse aiming is intended to be used with inputs that are mapped to mouse movement, such as gyro on Steam Deck.</b>
+					</p>
+					<p data-if="cur_config_index == 4">
+						Applies a deadzone to joystick inputs.
+					</p>
+					<p data-if="cur_config_index == 5">
+						Allows the game to read controller input when out of focus.
+						<br/>
+						<b>This setting does not affect keyboard input.</b>
+					</p>
+					<p data-if="cur_config_index == 6">
+						Turns on autosaving and prevents owl saves from being deleted on load. Autosaves act as owl saves and take up the same slot as they do.
+						<br/>
+						<br/>
+						Loading an autosave will place you in Clock Town or at the entrance of the current dungeon if you were in one.
+						<br/>
+						<br/>
+						<b>If autosaving is disabled, existing autosaves will be deleted when loaded.</b>
+					</p>
+					<p data-if="cur_config_index == 7">
+						Inverts the camera controls for first-person aiming. <b>Invert Y</b> is the default and matches the original game.
+					</p>
+					<p data-if="cur_config_index == 8">
+						Enables an analog "free" camera similar to later entries in the series that's mapped to the right analog stick on the controller.
+						<br/>
+						<br/>
+						When you move the right stick, the camera will enter free mode and stop centering behind Link. Press the <b>Target</b> button at any time to go back into the normal camera mode. The camera will also return to normal mode after a cutscene plays or when you move between areas.
+						<br/>
+						<br/>
+						This option also enables right stick control while looking and aiming.
+					</p>
+					<p data-if="cur_config_index == 9">
+						Inverts the camera controls for the analog camera if it's enabled. <b>None</b> is the default.
+					</p>
+					<p data-if="cur_config_index == 10">
+						Enables visibility of the special item HUD. Affects visibility only, functionality can be modified in the <b>Controls</b> setting tab. <b>On</b> is the default.
+					</p>
+				</div>
+			</div>
+		</form>
+	</body>
 </template>

--- a/include/zelda_config.h
+++ b/include/zelda_config.h
@@ -35,6 +35,9 @@ namespace zelda64 {
         {zelda64::AutosaveMode::Off, "Off"}
     });
 
+    AutosaveMode get_autosave_mode();
+    void set_autosave_mode(AutosaveMode mode);
+
     enum class TargetingMode {
         Switch,
         Hold,
@@ -81,11 +84,22 @@ namespace zelda64 {
         {zelda64::AnalogCamMode::Off, "Off"}
     });
 
-    AutosaveMode get_autosave_mode();
-    void set_autosave_mode(AutosaveMode mode);
-
     AnalogCamMode get_analog_cam_mode();
     void set_analog_cam_mode(AnalogCamMode mode);
+
+    enum class SpecialItemHudMode {
+        On,
+        Off,
+        OptionCount
+    };
+
+    NLOHMANN_JSON_SERIALIZE_ENUM(zelda64::SpecialItemHudMode, {
+        {zelda64::SpecialItemHudMode::On, "On"},
+        {zelda64::SpecialItemHudMode::Off, "Off"}
+        });
+
+    SpecialItemHudMode get_special_item_hud_mode();
+    void set_special_item_hud_mode(SpecialItemHudMode mode);
 
     void open_quit_game_prompt();
 };

--- a/patches/patches.h
+++ b/patches/patches.h
@@ -23,6 +23,7 @@
 #define gRandFloat sRandFloat
 #include "global.h"
 #include "rt64_extended_gbi.h"
+#include "patch_helpers.h"
 
 #ifndef gEXFillRectangle
 #define gEXFillRectangle(cmd, lorigin, rorigin, ulx, uly, lrx, lry) \
@@ -96,5 +97,7 @@ void room_load_hook(PlayState* play, Room* room);
 void draw_autosave_icon(PlayState* play);
 
 void recomp_crash(const char* err);
+
+DECLARE_FUNC(s32, recomp_special_item_hud_enabled);
 
 #endif

--- a/patches/syms.ld
+++ b/patches/syms.ld
@@ -44,3 +44,4 @@ recomp_get_inverted_axes = 0x8F0000A4;
 recomp_high_precision_fb_enabled = 0x8F0000A8;
 recomp_get_resolution_scale = 0x8F0000AC;
 recomp_get_analog_inverted_axes = 0x8F0000B0;
+recomp_special_item_hud_enabled = 0x8F0000B4;

--- a/patches/ui_patches.c
+++ b/patches/ui_patches.c
@@ -488,8 +488,10 @@ void Interface_Draw(PlayState* play) {
         
         // @recomp Draw the D-Pad and its item icons as well as the autosave icon if the game is unpaused.
         if (pauseCtx->state != PAUSE_STATE_MAIN) {
-            draw_dpad(play);
-            draw_dpad_icons(play);
+            if (recomp_special_item_hud_enabled()) {
+                draw_dpad(play);
+                draw_dpad_icons(play);
+            }
             draw_autosave_icon(play);
         }
 

--- a/src/game/config.cpp
+++ b/src/game/config.cpp
@@ -218,7 +218,8 @@ bool save_general_config(const std::filesystem::path& path) {
     config_json["joystick_deadzone"] = recomp::get_joystick_deadzone();
     config_json["autosave_mode"] = zelda64::get_autosave_mode();
     config_json["camera_invert_mode"] = zelda64::get_camera_invert_mode();
-    config_json["analog_cam_mode"] = zelda64::get_analog_cam_mode();
+    config_json["analog_cam_mode"] = zelda64::get_special_item_hud_mode();
+    config_json["special_item_hud_mode"] = zelda64::get_analog_cam_mode();
     config_json["analog_camera_invert_mode"] = zelda64::get_analog_camera_invert_mode();
     config_json["debug_mode"] = zelda64::get_debug_mode_enabled();
     
@@ -234,7 +235,7 @@ void set_general_settings_from_json(const nlohmann::json& config_json) {
     recomp::set_joystick_deadzone(from_or_default(config_json, "joystick_deadzone", 5));
     zelda64::set_autosave_mode(from_or_default(config_json, "autosave_mode", zelda64::AutosaveMode::On));
     zelda64::set_camera_invert_mode(from_or_default(config_json, "camera_invert_mode", zelda64::CameraInvertMode::InvertY));
-    zelda64::set_analog_cam_mode(from_or_default(config_json, "analog_cam_mode", zelda64::AnalogCamMode::Off));
+    zelda64::set_special_item_hud_mode(from_or_default(config_json, "special_item_hud_mode", zelda64::SpecialItemHudMode::On));
     zelda64::set_analog_camera_invert_mode(from_or_default(config_json, "analog_camera_invert_mode", zelda64::CameraInvertMode::InvertNone));
     zelda64::set_debug_mode_enabled(from_or_default(config_json, "debug_mode", false));
 }

--- a/src/game/config.cpp
+++ b/src/game/config.cpp
@@ -218,8 +218,8 @@ bool save_general_config(const std::filesystem::path& path) {
     config_json["joystick_deadzone"] = recomp::get_joystick_deadzone();
     config_json["autosave_mode"] = zelda64::get_autosave_mode();
     config_json["camera_invert_mode"] = zelda64::get_camera_invert_mode();
-    config_json["analog_cam_mode"] = zelda64::get_special_item_hud_mode();
-    config_json["special_item_hud_mode"] = zelda64::get_analog_cam_mode();
+    config_json["analog_cam_mode"] = zelda64::get_analog_cam_mode();
+    config_json["special_item_hud_mode"] = zelda64::get_special_item_hud_mode();
     config_json["analog_camera_invert_mode"] = zelda64::get_analog_camera_invert_mode();
     config_json["debug_mode"] = zelda64::get_debug_mode_enabled();
     
@@ -235,6 +235,7 @@ void set_general_settings_from_json(const nlohmann::json& config_json) {
     recomp::set_joystick_deadzone(from_or_default(config_json, "joystick_deadzone", 5));
     zelda64::set_autosave_mode(from_or_default(config_json, "autosave_mode", zelda64::AutosaveMode::On));
     zelda64::set_camera_invert_mode(from_or_default(config_json, "camera_invert_mode", zelda64::CameraInvertMode::InvertY));
+    zelda64::set_analog_cam_mode(from_or_default(config_json, "analog_cam_mode", zelda64::AnalogCamMode::Off));
     zelda64::set_special_item_hud_mode(from_or_default(config_json, "special_item_hud_mode", zelda64::SpecialItemHudMode::On));
     zelda64::set_analog_camera_invert_mode(from_or_default(config_json, "analog_camera_invert_mode", zelda64::CameraInvertMode::InvertNone));
     zelda64::set_debug_mode_enabled(from_or_default(config_json, "debug_mode", false));

--- a/src/game/recomp_api.cpp
+++ b/src/game/recomp_api.cpp
@@ -135,6 +135,10 @@ extern "C" void recomp_analog_cam_enabled(uint8_t* rdram, recomp_context* ctx) {
     _return<s32>(ctx, zelda64::get_analog_cam_mode() == zelda64::AnalogCamMode::On);
 }
 
+extern "C" void recomp_special_item_hud_enabled(uint8_t * rdram, recomp_context * ctx) {
+    _return<s32>(ctx, zelda64::get_special_item_hud_mode() == zelda64::SpecialItemHudMode::On);
+}
+
 extern "C" void recomp_get_camera_inputs(uint8_t* rdram, recomp_context* ctx) {
     float* x_out = _arg<0, float*>(rdram, ctx);
     float* y_out = _arg<1, float*>(rdram, ctx);

--- a/src/ui/ui_config.cpp
+++ b/src/ui/ui_config.cpp
@@ -290,6 +290,7 @@ struct ControlOptionsContext {
 	zelda64::AutosaveMode autosave_mode;
     zelda64::CameraInvertMode camera_invert_mode;
 	zelda64::AnalogCamMode analog_cam_mode;
+	zelda64::SpecialItemHudMode special_item_hud_mode;
     zelda64::CameraInvertMode analog_camera_invert_mode;
 };
 
@@ -397,6 +398,17 @@ void zelda64::set_analog_cam_mode(zelda64::AnalogCamMode mode) {
 	control_options_context.analog_cam_mode = mode;
 	if (general_model_handle) {
 		general_model_handle.DirtyVariable("analog_cam_mode");
+	}
+}
+
+zelda64::SpecialItemHudMode zelda64::get_special_item_hud_mode() {
+	return control_options_context.special_item_hud_mode;
+}
+
+void zelda64::set_special_item_hud_mode(zelda64::SpecialItemHudMode mode) {
+	control_options_context.special_item_hud_mode = mode;
+	if (general_model_handle) {
+		general_model_handle.DirtyVariable("special_item_hud_mode");
 	}
 }
 
@@ -937,6 +949,7 @@ public:
 		bind_option(constructor, "autosave_mode", &control_options_context.autosave_mode);
 		bind_option(constructor, "camera_invert_mode", &control_options_context.camera_invert_mode);
 		bind_option(constructor, "analog_cam_mode", &control_options_context.analog_cam_mode);
+		bind_option(constructor, "special_item_hud_mode", &control_options_context.special_item_hud_mode);
 		bind_option(constructor, "analog_camera_invert_mode", &control_options_context.analog_camera_invert_mode);
 
 		general_model_handle = constructor.GetModelHandle();


### PR DESCRIPTION
Implement menu item to toggle visibility of the special item hud.
Closed previous attempt, this is a new PR - This one puts the setting in the general menu and doesn't touch the sub modules.
Based on issue https://github.com/Zelda64Recomp/Zelda64Recomp/issues/168
Was marked as "good first issue" so I gave it a try.

![image](https://github.com/user-attachments/assets/719296eb-1433-4878-a3b7-4f782e6c2f4e)
![image](https://github.com/user-attachments/assets/6217741a-384b-4020-94a2-b7dfe41410c4)


Testing I did:
- Setting persists after toggle On and Off and after application exist and restart.
- Toggle shows and hides the "special item hud" based on setting when changed during gameplay.
- Navigating menu with arrows works without skipping any menu items.

Issues:
- The setting didn't fit, I added a scrollbar, but it's not behaving quite right. When you scroll using the controller or keyboard it doesn't go all the way.
- Also, how do you compile the scss?