### PR TITLE
Tag all patches with the RECOMP_PATCH attribute in preparation for the recompiler's strict mode

### DIFF
--- a/patches/actor_transform_tagging.c
+++ b/patches/actor_transform_tagging.c
@@ -8,7 +8,7 @@ extern FaultClient sActorFaultClient;
 Actor* Actor_Delete(ActorContext* actorCtx, Actor* actor, PlayState* play);
 void ZeldaArena_Free(void* ptr);
 
-void Actor_CleanupContext(ActorContext* actorCtx, PlayState* play) {
+RECOMP_PATCH void Actor_CleanupContext(ActorContext* actorCtx, PlayState* play) {
     s32 i;
 
     Fault_RemoveClient(&sActorFaultClient);
@@ -47,7 +47,7 @@ u32 create_actor_transform_id() {
     return ret;
 }
 
-void Actor_Init(Actor* actor, PlayState* play) {
+RECOMP_PATCH void Actor_Init(Actor* actor, PlayState* play) {
     Actor_SetWorldToHome(actor);
     Actor_SetShapeRotToWorld(actor);
     Actor_SetFocus(actor, 0.0f);
@@ -135,7 +135,7 @@ Gfx* pop_post_limb_matrix_group(Gfx* dlist, Actor* actor) {
 /*
  * Draws the limb at `limbIndex` with a level of detail display lists index by `dListIndex`
  */
-void SkelAnime_DrawLimbLod(PlayState* play, s32 limbIndex, void** skeleton, Vec3s* jointTable,
+RECOMP_PATCH void SkelAnime_DrawLimbLod(PlayState* play, s32 limbIndex, void** skeleton, Vec3s* jointTable,
                            OverrideLimbDrawOpa overrideLimbDraw, PostLimbDrawOpa postLimbDraw, Actor* actor, s32 lod) {
     LodLimb* limb;
     Gfx* dList;
@@ -197,7 +197,7 @@ void SkelAnime_DrawLimbLod(PlayState* play, s32 limbIndex, void** skeleton, Vec3
  * Draw all limbs of type `LodLimb` in a given skeleton
  * Near or far display list is specified via `lod`
  */
-void SkelAnime_DrawLod(PlayState* play, void** skeleton, Vec3s* jointTable, OverrideLimbDrawOpa overrideLimbDraw,
+RECOMP_PATCH void SkelAnime_DrawLod(PlayState* play, void** skeleton, Vec3s* jointTable, OverrideLimbDrawOpa overrideLimbDraw,
                        PostLimbDrawOpa postLimbDraw, Actor* actor, s32 lod) {
     LodLimb* rootLimb;
     s32 pad;
@@ -261,7 +261,7 @@ void SkelAnime_DrawLod(PlayState* play, void** skeleton, Vec3s* jointTable, Over
  * Draw a limb of type `LodLimb` contained within a flexible skeleton
  * Near or far display list is specified via `lod`
  */
-void SkelAnime_DrawFlexLimbLod(PlayState* play, s32 limbIndex, void** skeleton, Vec3s* jointTable,
+RECOMP_PATCH void SkelAnime_DrawFlexLimbLod(PlayState* play, s32 limbIndex, void** skeleton, Vec3s* jointTable,
                                OverrideLimbDrawFlex overrideLimbDraw, PostLimbDrawFlex postLimbDraw, Actor* actor,
                                s32 lod, Mtx** mtx) {
     LodLimb* limb;
@@ -332,7 +332,7 @@ void SkelAnime_DrawFlexLimbLod(PlayState* play, s32 limbIndex, void** skeleton, 
  * Limbs in a flexible skeleton have meshes that can stretch to line up with other limbs.
  * An array of matrices is dynamically allocated so each limb can access any transform to ensure its meshes line up.
  */
-void SkelAnime_DrawFlexLod(PlayState* play, void** skeleton, Vec3s* jointTable, s32 dListCount,
+RECOMP_PATCH void SkelAnime_DrawFlexLod(PlayState* play, void** skeleton, Vec3s* jointTable, s32 dListCount,
                            OverrideLimbDrawFlex overrideLimbDraw, PostLimbDrawFlex postLimbDraw, Actor* actor,
                            s32 lod) {
     LodLimb* rootLimb;
@@ -403,7 +403,7 @@ void SkelAnime_DrawFlexLod(PlayState* play, void** skeleton, Vec3s* jointTable, 
 /*
  * Draws the limb of the Skeleton `skeleton` at `limbIndex`
  */
-void SkelAnime_DrawLimbOpa(PlayState* play, s32 limbIndex, void** skeleton, Vec3s* jointTable,
+RECOMP_PATCH void SkelAnime_DrawLimbOpa(PlayState* play, s32 limbIndex, void** skeleton, Vec3s* jointTable,
                            OverrideLimbDrawOpa overrideLimbDraw, PostLimbDrawOpa postLimbDraw, Actor* actor) {
     StandardLimb* limb;
     Gfx* dList;
@@ -463,7 +463,7 @@ void SkelAnime_DrawLimbOpa(PlayState* play, s32 limbIndex, void** skeleton, Vec3
 /**
  * Draw all limbs of type `StandardLimb` in a given skeleton to the polyOpa buffer
  */
-void SkelAnime_DrawOpa(PlayState* play, void** skeleton, Vec3s* jointTable, OverrideLimbDrawOpa overrideLimbDraw,
+RECOMP_PATCH void SkelAnime_DrawOpa(PlayState* play, void** skeleton, Vec3s* jointTable, OverrideLimbDrawOpa overrideLimbDraw,
                        PostLimbDrawOpa postLimbDraw, Actor* actor) {
     StandardLimb* rootLimb;
     s32 pad;
@@ -521,7 +521,7 @@ void SkelAnime_DrawOpa(PlayState* play, void** skeleton, Vec3s* jointTable, Over
     CLOSE_DISPS(play->state.gfxCtx);
 }
 
-void SkelAnime_DrawFlexLimbOpa(PlayState* play, s32 limbIndex, void** skeleton, Vec3s* jointTable,
+RECOMP_PATCH void SkelAnime_DrawFlexLimbOpa(PlayState* play, s32 limbIndex, void** skeleton, Vec3s* jointTable,
                                OverrideLimbDrawOpa overrideLimbDraw, PostLimbDrawOpa postLimbDraw, Actor* actor,
                                Mtx** limbMatricies) {
     StandardLimb* limb;
@@ -591,7 +591,7 @@ void SkelAnime_DrawFlexLimbOpa(PlayState* play, s32 limbIndex, void** skeleton, 
  * Limbs in a flexible skeleton have meshes that can stretch to line up with other limbs.
  * An array of matrices is dynamically allocated so each limb can access any transform to ensure its meshes line up.
  */
-void SkelAnime_DrawFlexOpa(PlayState* play, void** skeleton, Vec3s* jointTable, s32 dListCount,
+RECOMP_PATCH void SkelAnime_DrawFlexOpa(PlayState* play, void** skeleton, Vec3s* jointTable, s32 dListCount,
                            OverrideLimbDrawOpa overrideLimbDraw, PostLimbDrawOpa postLimbDraw, Actor* actor) {
     StandardLimb* rootLimb;
     s32 pad;
@@ -661,7 +661,7 @@ void SkelAnime_DrawFlexOpa(PlayState* play, void** skeleton, Vec3s* jointTable, 
     CLOSE_DISPS(play->state.gfxCtx);
 }
 
-void SkelAnime_DrawTransformFlexLimbOpa(PlayState* play, s32 limbIndex, void** skeleton, Vec3s* jointTable,
+RECOMP_PATCH void SkelAnime_DrawTransformFlexLimbOpa(PlayState* play, s32 limbIndex, void** skeleton, Vec3s* jointTable,
                                         OverrideLimbDrawOpa overrideLimbDraw, PostLimbDrawOpa postLimbDraw,
                                         TransformLimbDrawOpa transformLimbDraw, Actor* actor, Mtx** mtx) {
     StandardLimb* limb;
@@ -744,7 +744,7 @@ void SkelAnime_DrawTransformFlexLimbOpa(PlayState* play, s32 limbIndex, void** s
  * coordinates.
  * Note that the `TransformLimbDraw` does not have a NULL check, so must be provided even if empty.
  */
-void SkelAnime_DrawTransformFlexOpa(PlayState* play, void** skeleton, Vec3s* jointTable, s32 dListCount,
+RECOMP_PATCH void SkelAnime_DrawTransformFlexOpa(PlayState* play, void** skeleton, Vec3s* jointTable, s32 dListCount,
                                     OverrideLimbDrawOpa overrideLimbDraw, PostLimbDrawOpa postLimbDraw,
                                     TransformLimbDrawOpa transformLimbDraw, Actor* actor) {
     StandardLimb* rootLimb;
@@ -825,7 +825,7 @@ void SkelAnime_DrawTransformFlexOpa(PlayState* play, void** skeleton, Vec3s* joi
  * Draws the Skeleton `skeleton`'s limb at index `limbIndex`.  Appends all generated graphics commands to
  * `gfx`.  Returns a pointer to the next gfx to be appended to.
  */
-Gfx* SkelAnime_DrawLimb(PlayState* play, s32 limbIndex, void** skeleton, Vec3s* jointTable,
+RECOMP_PATCH Gfx* SkelAnime_DrawLimb(PlayState* play, s32 limbIndex, void** skeleton, Vec3s* jointTable,
                         OverrideLimbDraw overrideLimbDraw, PostLimbDraw postLimbDraw, Actor* actor, Gfx* gfx) {
     StandardLimb* limb;
     Gfx* dList;
@@ -884,7 +884,7 @@ Gfx* SkelAnime_DrawLimb(PlayState* play, s32 limbIndex, void** skeleton, Vec3s* 
  * Draws the Skeleton `skeleton`  Appends all generated graphics to `gfx`, and returns a pointer to the
  * next gfx to be appended to.
  */
-Gfx* SkelAnime_Draw(PlayState* play, void** skeleton, Vec3s* jointTable, OverrideLimbDraw overrideLimbDraw,
+RECOMP_PATCH Gfx* SkelAnime_Draw(PlayState* play, void** skeleton, Vec3s* jointTable, OverrideLimbDraw overrideLimbDraw,
                     PostLimbDraw postLimbDraw, Actor* actor, Gfx* gfx) {
     StandardLimb* rootLimb;
     s32 pad;
@@ -944,7 +944,7 @@ Gfx* SkelAnime_Draw(PlayState* play, void** skeleton, Vec3s* jointTable, Overrid
 /**
  * Draw a limb of type `StandardLimb` contained within a flexible skeleton to the specified display buffer
  */
-Gfx* SkelAnime_DrawFlexLimb(PlayState* play, s32 limbIndex, void** skeleton, Vec3s* jointTable,
+RECOMP_PATCH Gfx* SkelAnime_DrawFlexLimb(PlayState* play, s32 limbIndex, void** skeleton, Vec3s* jointTable,
                             OverrideLimbDraw overrideLimbDraw, PostLimbDraw postLimbDraw, Actor* actor, Mtx** mtx,
                             Gfx* gfx) {
     StandardLimb* limb;
@@ -1014,7 +1014,7 @@ Gfx* SkelAnime_DrawFlexLimb(PlayState* play, s32 limbIndex, void** skeleton, Vec
  * Limbs in a flexible skeleton have meshes that can stretch to line up with other limbs.
  * An array of matrices is dynamically allocated so each limb can access any transform to ensure its meshes line up.
  */
-Gfx* SkelAnime_DrawFlex(PlayState* play, void** skeleton, Vec3s* jointTable, s32 dListCount,
+RECOMP_PATCH Gfx* SkelAnime_DrawFlex(PlayState* play, void** skeleton, Vec3s* jointTable, s32 dListCount,
                         OverrideLimbDraw overrideLimbDraw, PostLimbDraw postLimbDraw, Actor* actor, Gfx* gfx) {
     StandardLimb* rootLimb;
     s32 pad;
@@ -1085,7 +1085,7 @@ Gfx* SkelAnime_DrawFlex(PlayState* play, void** skeleton, Vec3s* jointTable, s32
 
 extern MtxF gSkinLimbMatrices[];
 
-void Skin_DrawImpl(Actor* actor, PlayState* play, Skin* skin, SkinPostDraw postDraw,
+RECOMP_PATCH void Skin_DrawImpl(Actor* actor, PlayState* play, Skin* skin, SkinPostDraw postDraw,
                    SkinOverrideLimbDraw overrideLimbDraw, s32 setTranslation, s32 arg6, s32 drawFlags) {
     s32 i;
     SkinLimb** skeleton;
@@ -1145,7 +1145,7 @@ close_disps:;
     CLOSE_DISPS(gfxCtx);
 }
 
-__attribute__((noinline)) s32 scan_for_matrices(Gfx* start, Gfx* end) {
+s32 scan_for_matrices(Gfx* start, Gfx* end) {
     s32 matrix_count = 0;
     Gfx* cur = start;
     // Count any G_MTX commands between the start and end commands.
@@ -1201,7 +1201,7 @@ void tag_actor_displaylists(Actor* actor, PlayState* play, Gfx* opa_start, Gfx* 
 }
 
 // @recomp Patched to automatically add transform tagging to actor matrices based on what DL commands they write in their draw function
-void Actor_Draw(PlayState* play, Actor* actor) {
+RECOMP_PATCH void Actor_Draw(PlayState* play, Actor* actor) {
     Lights* light;
 
     OPEN_DISPS(play->state.gfxCtx);

--- a/patches/autosaving.c
+++ b/patches/autosaving.c
@@ -14,7 +14,7 @@ s32 ShrinkWindow_Letterbox_GetSizeTarget(void);
 void ShrinkWindow_Letterbox_SetSizeTarget(s32 target);
 
 // @recomp Patched function to set a global variable if the player can pause
-void KaleidoSetup_Update(PlayState* play) {
+RECOMP_PATCH void KaleidoSetup_Update(PlayState* play) {
     Input* input = CONTROLLER1(&play->state);
     MessageContext* msgCtx = &play->msgCtx;
     Player* player = GET_PLAYER(play);
@@ -100,7 +100,7 @@ void do_autosave(PlayState* play) {
 }
 
 // @recomp Do not clear the save if the save was an autosave.
-void func_80147314(SramContext* sramCtx, s32 fileNum) {
+RECOMP_PATCH void func_80147314(SramContext* sramCtx, s32 fileNum) {
     s32 save_type = gSaveContext.save.isOwlSave;
     gSaveContext.save.isOwlSave = false;
 
@@ -156,7 +156,7 @@ void delete_owl_save(SramContext* sramCtx, s32 fileNum) {
 }
 
 // @recomp Patched to delete owl saves when making regular saves.
-void func_8014546C(SramContext* sramCtx) {
+RECOMP_PATCH void func_8014546C(SramContext* sramCtx) {
     s32 i;
 
     if (gSaveContext.save.isOwlSave) {
@@ -199,7 +199,7 @@ extern u16 D_801F6AF0;
 extern u8 D_801F6AF2;
 
 // @recomp Patched to call the new owl save deletion function.
-void Sram_EraseSave(FileSelectState* fileSelect2, SramContext* sramCtx, s32 fileNum) {
+RECOMP_PATCH void Sram_EraseSave(FileSelectState* fileSelect2, SramContext* sramCtx, s32 fileNum) {
     FileSelectState* fileSelect = fileSelect2;
     s32 pad;
 
@@ -468,7 +468,7 @@ extern s16 sSceneCutsceneCount;
 bool skip_entry_cutscene = false;
 
 // @recomp Patched to skip the entrance cutscene if the flag is enabled.
-s16 CutsceneManager_FindEntranceCsId(void) {
+RECOMP_PATCH s16 CutsceneManager_FindEntranceCsId(void) {
     PlayState* play;
     s32 csId;
 
@@ -523,7 +523,7 @@ s32 spawn_entrance_from_autosave_entrance(s16 autosave_entrance) {
 }
 
 // @recomp Patched to change the entrance for autosaves and initialize autosaves.
-void Sram_OpenSave(FileSelectState* fileSelect, SramContext* sramCtx) {
+RECOMP_PATCH void Sram_OpenSave(FileSelectState* fileSelect, SramContext* sramCtx) {
     s32 i;
     s32 pad;
     s32 phi_t1 = 0;
@@ -658,7 +658,7 @@ void Sram_OpenSave(FileSelectState* fileSelect, SramContext* sramCtx) {
 extern s32 Actor_ProcessTalkRequest(Actor* actor, GameState* gameState);
 
 // @recomp Reset the autosave timer when the moon crashes.
-void Sram_ResetSaveFromMoonCrash(SramContext* sramCtx) {
+RECOMP_PATCH void Sram_ResetSaveFromMoonCrash(SramContext* sramCtx) {
     s32 i;
     s32 cutsceneIndex = gSaveContext.save.cutsceneIndex;
 
@@ -710,7 +710,7 @@ void Sram_ResetSaveFromMoonCrash(SramContext* sramCtx) {
 
 
 // @recomp If autosave is enabled, skip the part of the owl statue dialog that talks about the file being deleted on load, since it's not true.
-void ObjWarpstone_Update(Actor* thisx, PlayState* play) {
+RECOMP_PATCH void ObjWarpstone_Update(Actor* thisx, PlayState* play) {
     ObjWarpstone* this = (ObjWarpstone*)thisx;
     s32 pad;
 

--- a/patches/billboard_tagging.c
+++ b/patches/billboard_tagging.c
@@ -61,7 +61,7 @@ void edit_billboard_groups(PlayState* play) {
     CLOSE_DISPS(play->state.gfxCtx);
 }
 
-Mtx* Matrix_NewMtx(GraphicsContext* gfxCtx) {
+RECOMP_PATCH Mtx* Matrix_NewMtx(GraphicsContext* gfxCtx) {
     Mtx* ret = Matrix_ToMtx(GRAPH_ALLOC(gfxCtx, sizeof(Mtx)));
 
     if (*current_billboard_state) {
@@ -77,7 +77,7 @@ Mtx* Matrix_NewMtx(GraphicsContext* gfxCtx) {
     return ret;
 }
 
-void Matrix_Init(GameState* gameState) {
+RECOMP_PATCH void Matrix_Init(GameState* gameState) {
     sMatrixStack = THA_AllocTailAlign16(&gameState->tha, MATRIX_STACK_SIZE * sizeof(MtxF));
     sCurrentMatrix = sMatrixStack;
 
@@ -94,7 +94,7 @@ void matrix_play_update(PlayState* play) {
     play_billboard_matrix = &play->billboardMtxF;
 }
 
-void Matrix_Push(void) {
+RECOMP_PATCH void Matrix_Push(void) {
     MtxF* prev = sCurrentMatrix;
 
     sCurrentMatrix++;
@@ -106,20 +106,20 @@ void Matrix_Push(void) {
     *current_billboard_state = *prev_billboard;
 }
 
-void Matrix_Pop(void) {
+RECOMP_PATCH void Matrix_Pop(void) {
     sCurrentMatrix--;
     // @recomp Pop the matrix stack billboard state.
     current_billboard_state--;
 }
 
-void Matrix_Put(MtxF* src) {
+RECOMP_PATCH void Matrix_Put(MtxF* src) {
     Matrix_MtxFCopy(sCurrentMatrix, src);
 
     // @recomp Update the current billboard state.
     *current_billboard_state = (src == play_billboard_matrix);
 }
 
-void Matrix_ReplaceRotation(MtxF* mf) {
+RECOMP_PATCH void Matrix_ReplaceRotation(MtxF* mf) {
     MtxF* cmf = sCurrentMatrix;
     f32 acc;
     f32 component;
@@ -168,7 +168,7 @@ void Matrix_ReplaceRotation(MtxF* mf) {
     *current_billboard_state = (mf == play_billboard_matrix);
 }
 
-void Matrix_Mult(MtxF* mf, MatrixMode mode) {
+RECOMP_PATCH void Matrix_Mult(MtxF* mf, MatrixMode mode) {
     MtxF* cmf = Matrix_GetCurrent();
 
     if (mode == MTXMODE_APPLY) {
@@ -183,7 +183,7 @@ void Matrix_Mult(MtxF* mf, MatrixMode mode) {
     }
 }
 
-void Matrix_Translate(f32 x, f32 y, f32 z, MatrixMode mode) {
+RECOMP_PATCH void Matrix_Translate(f32 x, f32 y, f32 z, MatrixMode mode) {
     MtxF* cmf = sCurrentMatrix;
     f32 tempX;
     f32 tempY;
@@ -209,7 +209,7 @@ void Matrix_Translate(f32 x, f32 y, f32 z, MatrixMode mode) {
     }
 }
 
-void Matrix_Scale(f32 x, f32 y, f32 z, MatrixMode mode) {
+RECOMP_PATCH void Matrix_Scale(f32 x, f32 y, f32 z, MatrixMode mode) {
     MtxF* cmf = sCurrentMatrix;
 
     if (mode == MTXMODE_APPLY) {
@@ -233,7 +233,7 @@ void Matrix_Scale(f32 x, f32 y, f32 z, MatrixMode mode) {
     }
 }
 
-void Matrix_RotateXS(s16 x, MatrixMode mode) {
+RECOMP_PATCH void Matrix_RotateXS(s16 x, MatrixMode mode) {
     MtxF* cmf;
     f32 sin;
     f32 cos;
@@ -300,7 +300,7 @@ void Matrix_RotateXS(s16 x, MatrixMode mode) {
     }
 }
 
-void Matrix_RotateXF(f32 x, MatrixMode mode) {
+RECOMP_PATCH void Matrix_RotateXF(f32 x, MatrixMode mode) {
     MtxF* cmf;
     f32 sin;
     f32 cos;
@@ -369,7 +369,7 @@ void Matrix_RotateXF(f32 x, MatrixMode mode) {
     }
 }
 
-void Matrix_RotateXFNew(f32 x) {
+RECOMP_PATCH void Matrix_RotateXFNew(f32 x) {
     MtxF* cmf = sCurrentMatrix;
     s32 pad[2];
     f32 sin;
@@ -406,7 +406,7 @@ void Matrix_RotateXFNew(f32 x) {
     // @recomp Clear the current billboard state.
     *current_billboard_state = false;
 }
-void Matrix_RotateYS(s16 y, MatrixMode mode) {
+RECOMP_PATCH void Matrix_RotateYS(s16 y, MatrixMode mode) {
     MtxF* cmf;
     f32 sin;
     f32 cos;
@@ -473,7 +473,7 @@ void Matrix_RotateYS(s16 y, MatrixMode mode) {
     }
 }
 
-void Matrix_RotateYF(f32 y, MatrixMode mode) {
+RECOMP_PATCH void Matrix_RotateYF(f32 y, MatrixMode mode) {
     MtxF* cmf;
     f32 sin;
     f32 cos;
@@ -542,7 +542,7 @@ void Matrix_RotateYF(f32 y, MatrixMode mode) {
     }
 }
 
-void Matrix_RotateZS(s16 z, MatrixMode mode) {
+RECOMP_PATCH void Matrix_RotateZS(s16 z, MatrixMode mode) {
     MtxF* cmf;
     f32 sin;
     f32 cos;
@@ -611,7 +611,7 @@ void Matrix_RotateZS(s16 z, MatrixMode mode) {
     }
 }
 
-void Matrix_RotateZF(f32 z, MatrixMode mode) {
+RECOMP_PATCH void Matrix_RotateZF(f32 z, MatrixMode mode) {
     MtxF* cmf;
     f32 sin;
     f32 cos;
@@ -678,7 +678,7 @@ void Matrix_RotateZF(f32 z, MatrixMode mode) {
     }
 }
 
-void Matrix_RotateZYX(s16 x, s16 y, s16 z, MatrixMode mode) {
+RECOMP_PATCH void Matrix_RotateZYX(s16 x, s16 y, s16 z, MatrixMode mode) {
     MtxF* cmf = sCurrentMatrix;
     f32 temp1;
     f32 temp2;
@@ -768,7 +768,7 @@ void Matrix_RotateZYX(s16 x, s16 y, s16 z, MatrixMode mode) {
     }
 }
 
-void Matrix_SetTranslateRotateYXZ(f32 x, f32 y, f32 z, Vec3s* rot) {
+RECOMP_PATCH void Matrix_SetTranslateRotateYXZ(f32 x, f32 y, f32 z, Vec3s* rot) {
     MtxF* cmf = sCurrentMatrix;
     f32 sinY = Math_SinS(rot->y);
     f32 cosY = Math_CosS(rot->y);
@@ -829,7 +829,7 @@ void Matrix_SetTranslateRotateYXZ(f32 x, f32 y, f32 z, Vec3s* rot) {
     *current_billboard_state = false;
 }
 
-void Matrix_RotateAxisF(f32 angle, Vec3f* axis, MatrixMode mode) {
+RECOMP_PATCH void Matrix_RotateAxisF(f32 angle, Vec3f* axis, MatrixMode mode) {
     MtxF* cmf;
     f32 sin;
     f32 cos;
@@ -926,7 +926,7 @@ void Matrix_RotateAxisF(f32 angle, Vec3f* axis, MatrixMode mode) {
     }
 }
 
-void Matrix_RotateAxisS(s16 angle, Vec3f* axis, MatrixMode mode) {
+RECOMP_PATCH void Matrix_RotateAxisS(s16 angle, Vec3f* axis, MatrixMode mode) {
     MtxF* cmf;
     f32 cos;
     f32 sin;

--- a/patches/camera_patches.c
+++ b/patches/camera_patches.c
@@ -176,7 +176,7 @@ void Camera_UpdateInterface(s32 interfaceFlags);
 s32 func_800CB7CC(Camera* camera);
 s32 func_800CB854(Camera* camera);
 
-Vec3s Camera_Update(Camera* camera) {
+RECOMP_PATCH Vec3s Camera_Update(Camera* camera) {
     Vec3f viewAt;
     Vec3f viewEye;
     Vec3f viewUp;
@@ -461,7 +461,7 @@ s32 func_800CBA7C(Camera* camera);
 #define RELOAD_PARAMS(camera) ((camera->animState == 0) || (camera->animState == 10) || (camera->animState == 20))
 
 // @recomp Patched for analog cam.
-s32 Camera_Normal1(Camera* camera) {
+RECOMP_PATCH s32 Camera_Normal1(Camera* camera) {
     Vec3f* eye = &camera->eye;
     Vec3f* at = &camera->at;
     Vec3f* eyeNext = &camera->eyeNext;
@@ -870,7 +870,7 @@ s32 Camera_Normal1(Camera* camera) {
  * Camera for climbing structures
  */
 // @recomp Patched for analog cam.
-s32 Camera_Jump2(Camera* camera) {
+RECOMP_PATCH s32 Camera_Jump2(Camera* camera) {
     Vec3f* eye = &camera->eye;
     Vec3f* at = &camera->at;
     Vec3f* eyeNext = &camera->eyeNext;
@@ -1063,7 +1063,7 @@ s32 Camera_Jump2(Camera* camera) {
  * Used for targeting
  */
 // @recomp Patched for analog cam.
-s32 Camera_Parallel1(Camera* camera) {
+RECOMP_PATCH s32 Camera_Parallel1(Camera* camera) {
     Vec3f* eye = &camera->eye;
     Vec3f* at = &camera->at;
     Vec3f* eyeNext = &camera->eyeNext;
@@ -1421,7 +1421,7 @@ s32 Camera_Parallel1(Camera* camera) {
  * Riding Epona and Zora
  */
 // @recomp Patched for analog cam.
-s32 Camera_Normal3(Camera* camera) {
+RECOMP_PATCH s32 Camera_Normal3(Camera* camera) {
     Normal3ReadOnlyData* roData = &camera->paramData.norm3.roData;
     Normal3ReadWriteData* rwData = &camera->paramData.norm3.rwData;
     f32 sp8C;
@@ -1620,7 +1620,7 @@ s32 Camera_Normal3(Camera* camera) {
  * e.g. Gyorg, Pinnacle Rock, whirlpool, water
  */
 // @recomp Patched for analog cam.
-s32 Camera_Jump3(Camera* camera) {
+RECOMP_PATCH s32 Camera_Jump3(Camera* camera) {
     Vec3f* sp48 = &camera->eye;
     Vec3f* sp44 = &camera->at;
     Vec3f* sp40 = &camera->eyeNext;
@@ -1905,7 +1905,7 @@ extern u8 D_809EE4D0;
 
 // @recomp Patch the Wart boss fight in the Great Bay temple so that the fight starts if you look at it with the right stick analog camera,
 // instead of requiring entering first person mode mode.
-void func_809EC568(Boss04* this, PlayState* play) {
+RECOMP_PATCH void func_809EC568(Boss04* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
     f32 x;
     f32 y;

--- a/patches/camera_transform_tagging.c
+++ b/patches/camera_transform_tagging.c
@@ -95,7 +95,7 @@ void force_camera_ignore_tracking() {
     camera_ignore_tracking = true;
 }
 
-void KaleidoScope_SetView(PauseContext* pauseCtx, f32 eyeX, f32 eyeY, f32 eyeZ) {
+RECOMP_PATCH void KaleidoScope_SetView(PauseContext* pauseCtx, f32 eyeX, f32 eyeY, f32 eyeZ) {
     Vec3f eye;
     Vec3f at;
     Vec3f up;
@@ -117,7 +117,7 @@ void KaleidoScope_SetView(PauseContext* pauseCtx, f32 eyeX, f32 eyeY, f32 eyeZ) 
 }
 
 
-void FileSelect_SetView(FileSelectState* this, f32 eyeX, f32 eyeY, f32 eyeZ) {
+RECOMP_PATCH void FileSelect_SetView(FileSelectState* this, f32 eyeX, f32 eyeY, f32 eyeZ) {
     Vec3f eye;
     Vec3f lookAt;
     Vec3f up;
@@ -197,7 +197,7 @@ bool should_interpolate_perspective(Vec3f* eye, Vec3f* at) {
 /**
  * Apply view to POLY_OPA_DISP, POLY_XLU_DISP (and OVERLAY_DISP if ortho)
  */
-void View_Apply(View* view, s32 mask) {
+RECOMP_PATCH void View_Apply(View* view, s32 mask) {
     mask = (view->flags & mask) | (mask >> 4);
     
     // @recomp Determine if the camera should be interpolated this frame.
@@ -292,7 +292,7 @@ Vec3f Camera_Vec3sToVec3f(Vec3s* src);
  * Used for many fixed-based camera settings i.e. camera is fixed in rotation, and often position (but not always)
  */
 // @recomp Modified to not force interpolation while panning.
-s32 Camera_Fixed1(Camera* camera) {
+RECOMP_PATCH s32 Camera_Fixed1(Camera* camera) {
     s32 pad[2];
     s32 yawDiff;
     VecGeo eyeOffset;

--- a/patches/culling.c
+++ b/patches/culling.c
@@ -1,7 +1,7 @@
 #include "patches.h"
 
 // Disable frustum culling for actors, but leave distance culling intact
-s32 func_800BA2FC(PlayState* play, Actor* actor, Vec3f* projectedPos, f32 projectedW) {
+RECOMP_PATCH s32 func_800BA2FC(PlayState* play, Actor* actor, Vec3f* projectedPos, f32 projectedW) {
     if ((-actor->uncullZoneScale < projectedPos->z) &&
         (projectedPos->z < (actor->uncullZoneForward + actor->uncullZoneScale))) {
         // f32 phi_f12;
@@ -30,7 +30,7 @@ s32 func_800BA2FC(PlayState* play, Actor* actor, Vec3f* projectedPos, f32 projec
 }
 
 // Disable frustum culling for bush spawning
-// s32 EnWood02_SpawnZoneCheck(EnWood02* this, PlayState* play, Vec3f* arg2) {
+// RECOMP_PATCH s32 EnWood02_SpawnZoneCheck(EnWood02* this, PlayState* play, Vec3f* arg2) {
 //     f32 phi_f12;
 
 //     SkinMatrix_Vec3fMtxFMultXYZW(&play->viewProjectionMtxF, arg2, &this->actor.projectedPos, &this->actor.projectedW);
@@ -52,7 +52,7 @@ s32 func_800BA2FC(PlayState* play, Actor* actor, Vec3f* projectedPos, f32 projec
 // }
 
 // Disable frustum culling for grass
-s32 func_809A9110(PlayState* play, Vec3f* pos) {
+RECOMP_PATCH s32 func_809A9110(PlayState* play, Vec3f* pos) {
     f32 w;
     Vec3f projectedPos;
 
@@ -73,7 +73,7 @@ s32 func_809A9110(PlayState* play, Vec3f* pos) {
 
 // Replace point light glow effect with RT64 point Z test so it works in widescreen
 
-void Lights_GlowCheck(PlayState* play) {
+RECOMP_PATCH void Lights_GlowCheck(PlayState* play) {
     LightNode* light = play->lightCtx.listHead;
 
     while (light != NULL) {
@@ -107,7 +107,7 @@ extern Gfx gameplay_keep_DL_029CF0[];
 
 Vtx light_test_vert = VTX(0, 0, 0,  0, 0,  0xFF, 0xFF, 0xFF, 0xFF);
 
-void Lights_DrawGlow(PlayState* play) {
+RECOMP_PATCH void Lights_DrawGlow(PlayState* play) {
     Gfx* dl;
     LightPoint* params;
     LightNode* light = play->lightCtx.listHead;

--- a/patches/cutscene_patches.c
+++ b/patches/cutscene_patches.c
@@ -6,7 +6,7 @@
 
 CsCmdActorCue* prev_cues_checked[ARRAY_COUNT(((CutsceneContext*)0)->actorCues)] = {0};
 
-void Cutscene_ActorTranslate(Actor* actor, PlayState* play, s32 cueChannel) {
+RECOMP_PATCH void Cutscene_ActorTranslate(Actor* actor, PlayState* play, s32 cueChannel) {
     Vec3f startPos;
     Vec3f endPos;
     CsCmdActorCue* cue = play->csCtx.actorCues[cueChannel];
@@ -39,7 +39,7 @@ extern EnHorseCsFunc D_808890F0[];
 extern EnHorseCsFunc D_8088911C[];
 
 // @recomp Patched to skip interpolation on Epona when she's teleported by a cutscene.
-void func_80884718(EnHorse* this, PlayState* play) {
+RECOMP_PATCH void func_80884718(EnHorse* this, PlayState* play) {
     CsCmdActorCue* cue;
 
     if (Cutscene_IsCueInChannel(play, CS_CMD_ACTOR_CUE_112)) {
@@ -75,7 +75,7 @@ void func_80884718(EnHorse* this, PlayState* play) {
 }
 
 // @recomp Patched to skip interpolation on Epona when she's teleported by a cutscene.
-void func_80883B70(EnHorse* this, CsCmdActorCue* cue) {
+RECOMP_PATCH void func_80883B70(EnHorse* this, CsCmdActorCue* cue) {
     // @recomp Being teleported by a new cue, so skip interpolation.
     actor_set_interpolation_skipped(&this->actor);
 
@@ -90,7 +90,7 @@ void func_80883B70(EnHorse* this, CsCmdActorCue* cue) {
 }
 
 // @recomp Patched to skip interpolation on Link when he's teleported to a new cue.
-void Player_Cutscene_SetPosAndYawToStart(Player* this, CsCmdActorCue* cue) {
+RECOMP_PATCH void Player_Cutscene_SetPosAndYawToStart(Player* this, CsCmdActorCue* cue) {
     // @recomp Being teleported by a new cue, so skip interpolation.
     actor_set_interpolation_skipped(&this->actor);
 
@@ -104,7 +104,7 @@ void Player_Cutscene_SetPosAndYawToStart(Player* this, CsCmdActorCue* cue) {
 CsCmdActorCue* prev_link_cue = NULL;
 
 // @recomp Patched to skip interpolation on Link when he's teleported to a new cue.
-void Player_Cutscene_Translate(PlayState* play, Player* this, CsCmdActorCue* cue) {
+RECOMP_PATCH void Player_Cutscene_Translate(PlayState* play, Player* this, CsCmdActorCue* cue) {
     f32 startX = cue->startPos.x;
     f32 startY = cue->startPos.y;
     f32 startZ = cue->startPos.z;

--- a/patches/effect_patches.c
+++ b/patches/effect_patches.c
@@ -9,7 +9,7 @@ extern Gfx sTransWipe3DL[];
 
 #define THIS ((TransitionWipe3*)thisx)
 // @recomp patched to scale the transition based on aspect ratio
-void TransitionWipe3_Draw(void* thisx, Gfx** gfxP) {
+RECOMP_PATCH void TransitionWipe3_Draw(void* thisx, Gfx** gfxP) {
     Gfx* gfx = *gfxP;
     Mtx* modelView = &THIS->modelView[THIS->frame];
     f32 scale = 14.8f;
@@ -53,7 +53,7 @@ extern s32 gFramerateDivisor;
 
 // @recomp Motion blur works fine normally, but when running at a higher framerate the effect is much less pronounced
 // as the previous frames decay quicker due to there being more frames drawn in the same period of time.
-void Play_DrawMotionBlur(PlayState* this) {
+RECOMP_PATCH void Play_DrawMotionBlur(PlayState* this) {
     GraphicsContext* gfxCtx = this->state.gfxCtx;
     s32 alpha;
     Gfx* gfx;
@@ -126,7 +126,7 @@ void Play_DrawMotionBlur(PlayState* this) {
 }
 
 // @recomp Patched to increase the scale based on the aspect ratio.
-void Actor_DrawLensOverlay(Gfx** gfxP, s32 lensMaskSize) {
+RECOMP_PATCH void Actor_DrawLensOverlay(Gfx** gfxP, s32 lensMaskSize) {
     // @recomp Calculate the increase in aspect ratio.
     f32 original_aspect_ratio = (float)SCREEN_WIDTH / SCREEN_HEIGHT;
     f32 aspect_ratio_scale = recomp_get_aspect_ratio(original_aspect_ratio) / original_aspect_ratio;
@@ -139,7 +139,7 @@ void Actor_DrawLensOverlay(Gfx** gfxP, s32 lensMaskSize) {
 
 
 // @recomp Patched to use ortho tris for interpolation and to prevent the telescope and lens effects from getting stretched wide.
-void TransitionCircle_LoadAndSetTexture(Gfx** gfxp, TexturePtr texture, s32 fmt, s32 arg3, s32 masks, s32 maskt,
+RECOMP_PATCH void TransitionCircle_LoadAndSetTexture(Gfx** gfxp, TexturePtr texture, s32 fmt, s32 arg3, s32 masks, s32 maskt,
                                         f32 arg6) {
     Gfx* gfx = *gfxp;
     s32 xh = gCfbWidth;

--- a/patches/effect_transform_tagging.c
+++ b/patches/effect_transform_tagging.c
@@ -13,7 +13,7 @@ extern Gfx gEffDustDL[];
     ((&(particle).unk_1C)[1])
 
 // @recomp Patched to record when a particle is moved to skip interpolation.
-void func_808DC454(ObjectKankyo* this, PlayState* play) {
+RECOMP_PATCH void func_808DC454(ObjectKankyo* this, PlayState* play) {
     s16 i;
     s32 pad1;
     f32 phi_f20;
@@ -155,7 +155,7 @@ void func_808DC454(ObjectKankyo* this, PlayState* play) {
     }
 }
 
-void func_808DD3C8(Actor* thisx, PlayState* play2) {
+RECOMP_PATCH void func_808DD3C8(Actor* thisx, PlayState* play2) {
     PlayState* play = play2;
     ObjectKankyo* this = (ObjectKankyo*)thisx;
     Vec3f worldPos;
@@ -331,7 +331,7 @@ static inline void pop_effect_tag(GraphicsContext* gfxCtx) {
 }
 
 // @recomp Patched to tag effects.
-void Effect_DrawAll(GraphicsContext* gfxCtx) {
+RECOMP_PATCH void Effect_DrawAll(GraphicsContext* gfxCtx) {
     s32 i;
 
 
@@ -442,7 +442,7 @@ static TexturePtr sWaterSplashTextures[] = {
  * applies to all effects of that type while drawing the first effect of that type.
  */
 // @recomp Patched to tag matrices.
-void EnClearTag_DrawEffects(Actor* thisx, PlayState* play) {
+RECOMP_PATCH void EnClearTag_DrawEffects(Actor* thisx, PlayState* play) {
     u8 isMaterialApplied = false;
     s16 i;
     s16 j;
@@ -694,7 +694,7 @@ void EnClearTag_DrawEffects(Actor* thisx, PlayState* play) {
 }
 
 // @recomp Patched to tag the two custom lens flares (used by the Igos du Ikana curtains).
-void Environment_DrawCustomLensFlare(PlayState* play) {
+RECOMP_PATCH void Environment_DrawCustomLensFlare(PlayState* play) {
     Vec3f pos;
 
     // @recomp Set up the graphics context.
@@ -739,7 +739,7 @@ void Environment_DrawCustomLensFlare(PlayState* play) {
 }
 
 // @recomp Patched to tag the sun lens flare.
-void Environment_DrawSunLensFlare(PlayState* play, EnvironmentContext* envCtx, View* view, GraphicsContext* gfxCtx,
+RECOMP_PATCH void Environment_DrawSunLensFlare(PlayState* play, EnvironmentContext* envCtx, View* view, GraphicsContext* gfxCtx,
                                   Vec3f vec) {
     if ((play->envCtx.precipitation[PRECIP_RAIN_CUR] == 0) &&
         !(GET_ACTIVE_CAM(play)->stateFlags & CAM_STATE_UNDERWATER) && (play->skyboxId == SKYBOX_NORMAL_SKY)) {

--- a/patches/fixes.c
+++ b/patches/fixes.c
@@ -25,7 +25,7 @@ s16 sVtxPageGameOverSaveQuadsY[VTX_PAGE_SAVE_QUADS] = {
 };
 
 // @recomp patched to draw as strips with bilerp compensation instead of tiles.
-s16 KaleidoScope_SetPageVertices(PlayState* play, Vtx* vtx, s16 vtxPage, s16 numQuads) {
+RECOMP_PATCH s16 KaleidoScope_SetPageVertices(PlayState* play, Vtx* vtx, s16 vtxPage, s16 numQuads) {
     PauseContext* pauseCtx = &play->pauseCtx;
     GameOverContext* gameOverCtx = &play->gameOverCtx;
     s16* quadsX;
@@ -204,7 +204,7 @@ void KaleidoDrawWrapper(PlayState* play) {
     }
 }
 
-void KaleidoScopeCall_Init(PlayState* play) {
+RECOMP_PATCH void KaleidoScopeCall_Init(PlayState* play) {
     // @recomp Set the update and draw func pointers to the wrappers instead of the actual functions.
     sKaleidoScopeUpdateFunc = KaleidoUpdateWrapper;
     sKaleidoScopeDrawFunc = KaleidoDrawWrapper;
@@ -212,7 +212,7 @@ void KaleidoScopeCall_Init(PlayState* play) {
 }
 
 // @recomp patched to fix bilerp seams.
-Gfx* KaleidoScope_DrawPageSections(Gfx* gfx, Vtx* vertices, TexturePtr* textures) {
+RECOMP_PATCH Gfx* KaleidoScope_DrawPageSections(Gfx* gfx, Vtx* vertices, TexturePtr* textures) {
     s32 i;
     s32 j;
 
@@ -264,7 +264,7 @@ int extra_vis = 0;
 
 // @recomp Patch the giants cutscene to make certain frames take longer to mimic performance on console.
 // This prevents the music from desyncing from the cutscene as it was designed around the console's frame times.
-void Cutscene_UpdateScripted(PlayState* play, CutsceneContext* csCtx) {
+RECOMP_PATCH void Cutscene_UpdateScripted(PlayState* play, CutsceneContext* csCtx) {
     if ((gSaveContext.cutsceneTrigger != 0) && (play->transitionTrigger == TRANS_TRIGGER_START)) {
         gSaveContext.cutsceneTrigger = 0;
     }
@@ -297,7 +297,7 @@ void Cutscene_UpdateScripted(PlayState* play, CutsceneContext* csCtx) {
 }
 
 // @recomp Fix a texture scroll using an incorrect tile size, which resulted in the scroll jumping during the animation.
-s32 DemoEffect_OverrideLimbDrawTimewarp(PlayState* play, SkelCurve* skelCurve, s32 limbIndex, Actor* thisx) {
+RECOMP_PATCH s32 DemoEffect_OverrideLimbDrawTimewarp(PlayState* play, SkelCurve* skelCurve, s32 limbIndex, Actor* thisx) {
     s32 pad;
     DemoEffect* this = (DemoEffect*)thisx;
     u32 frames = play->gameplayFrames;
@@ -333,7 +333,7 @@ void DayTelop_Noop(DayTelopState* this);
 void DayTelop_LoadGraphics(DayTelopState* this);
 
 // @recomp Increase the length of the "Dawn of the X Day" screen to account for faster loading.
-void DayTelop_Init(GameState* thisx) {
+RECOMP_PATCH void DayTelop_Init(GameState* thisx) {
     DayTelopState* this = (DayTelopState*)thisx;
 
     GameState_SetFramerateDivisor(&this->state, 1);
@@ -371,7 +371,7 @@ void func_80836A5C(Player* this, PlayState* play);
 s32 func_8082DA90(PlayState* play);
 
 // @recomp Patched to fix the issue where ocarina inputs are discarded for the first 3 frames (150ms).
-void Player_Action_63(Player* this, PlayState* play) {
+RECOMP_PATCH void Player_Action_63(Player* this, PlayState* play) {
     if ((this->unk_AA5 != PLAYER_UNKAA5_4) && ((PlayerAnimation_Update(play, &this->skelAnime) &&
                                                 (this->skelAnime.animation == D_8085D17C[this->transformation])) ||
                                                ((this->skelAnime.mode == 0) && (this->av2.actionVar2 == 0)))) {

--- a/patches/input.c
+++ b/patches/input.c
@@ -11,7 +11,7 @@ s16 func_80832754(Player* this, s32 arg1);
 s32 func_8082EF20(Player* this);
 
 // @recomp Patched to add gyro and mouse aiming.
-s32 func_80847190(PlayState* play, Player* this, s32 arg2) {
+RECOMP_PATCH s32 func_80847190(PlayState* play, Player* this, s32 arg2) {
     s32 pad;
     s16 var_s0;
     // @recomp Get the aiming camera inversion state.
@@ -147,7 +147,7 @@ extern Input* sPlayerControlInput;
  * - B exits, using the RESPAWN_MODE_DOWN entrance
  */
 // @recomp Patched for aiming inversion and supporting the right stick in dual analog.
-void func_8083A98C(Actor* thisx, PlayState* play2) {
+RECOMP_PATCH void func_8083A98C(Actor* thisx, PlayState* play2) {
     PlayState* play = play2;
     Player* this = (Player*)thisx;
     s32 camMode;
@@ -351,7 +351,7 @@ u8* get_button_item_equip_ptr(u32 form, u32 button) {
 }
 
 // Return currently-pressed button, in order of priority D-Pad, B, CLEFT, CDOWN, CRIGHT.
-EquipSlot func_8082FDC4(void) {
+RECOMP_PATCH EquipSlot func_8082FDC4(void) {
     EquipSlot i;
 
     for (int extra_slot_index = 0; extra_slot_index < ARRAY_COUNT(buttons_to_extra_slot); extra_slot_index++) {
@@ -369,7 +369,7 @@ EquipSlot func_8082FDC4(void) {
     return i;
 }
 
-ItemId Player_GetItemOnButton(PlayState* play, Player* player, EquipSlot slot) {
+RECOMP_PATCH ItemId Player_GetItemOnButton(PlayState* play, Player* player, EquipSlot slot) {
     if (slot >= EQUIP_SLOT_A) {
         return ITEM_NONE;
     }
@@ -444,7 +444,7 @@ bool func_808323C0(Player *this, s16 csId);
 void func_80855218(PlayState *play, Player *this, struct_8085D910 **arg2);
 void func_808550D0(PlayState *play, Player *this, f32 arg2, f32 arg3, s32 arg4);
 
-void Player_Action_86(Player *this, PlayState *play) {
+RECOMP_PATCH void Player_Action_86(Player *this, PlayState *play) {
     struct_8085D910 *sp4C = D_8085D910;
     s32 sp48 = false;
 
@@ -540,7 +540,7 @@ extern void* gWorkBuffer;
 u16 func_801A5100(void);
 
 // @recomp Patched to update status of extra buttons via set_extra_item_slot_status.
-void Interface_UpdateButtonsPart1(PlayState* play) {
+RECOMP_PATCH void Interface_UpdateButtonsPart1(PlayState* play) {
     InterfaceContext* interfaceCtx = &play->interfaceCtx;
     Player* player = GET_PLAYER(play);
     s32 pad;
@@ -807,7 +807,7 @@ void Interface_UpdateButtonsPart1(PlayState* play) {
  * Also used directly when opening the pause menu i.e. skips part 1
  */
 // @recomp Patched in the same way as Interface_UpdateButtonsPart1
-void Interface_UpdateButtonsPart2(PlayState* play) {
+RECOMP_PATCH void Interface_UpdateButtonsPart2(PlayState* play) {
     MessageContext* msgCtx = &play->msgCtx;
     InterfaceContext* interfaceCtx = &play->interfaceCtx;
     Player* player = GET_PLAYER(play);
@@ -1300,7 +1300,7 @@ void Interface_UpdateButtonsPart2(PlayState* play) {
  * Sets the button alphas to be dimmed for disabled buttons, or to the requested alpha for non-disabled buttons
  */
 // @recomp Patched to also set extra slot alpha values.
-void Interface_UpdateButtonAlphasByStatus(PlayState* play, s16 risingAlpha) {
+RECOMP_PATCH void Interface_UpdateButtonAlphasByStatus(PlayState* play, s16 risingAlpha) {
     InterfaceContext* interfaceCtx = &play->interfaceCtx;
 
     if ((gSaveContext.buttonStatus[EQUIP_SLOT_B] == BTN_DISABLED) || (gSaveContext.bButtonStatus == BTN_DISABLED)) {
@@ -1373,7 +1373,7 @@ void Interface_UpdateButtonAlphasByStatus(PlayState* play, s16 risingAlpha) {
  * depending on button status
  */
 // @recomp Patched to also set extra slot alpha values.
-void Interface_UpdateButtonAlphas(PlayState* play, s16 dimmingAlpha, s16 risingAlpha) {
+RECOMP_PATCH void Interface_UpdateButtonAlphas(PlayState* play, s16 dimmingAlpha, s16 risingAlpha) {
     InterfaceContext* interfaceCtx = &play->interfaceCtx;
 
     if (gSaveContext.hudVisibilityForceButtonAlphasByStatus) {
@@ -1410,7 +1410,7 @@ void Interface_UpdateButtonAlphas(PlayState* play, s16 dimmingAlpha, s16 risingA
 }
 
 // @recomp Patched to also set extra slot alpha values.
-void Interface_UpdateHudAlphas(PlayState* play, s16 dimmingAlpha) {
+RECOMP_PATCH void Interface_UpdateHudAlphas(PlayState* play, s16 dimmingAlpha) {
     InterfaceContext* interfaceCtx = &play->interfaceCtx;
     s16 risingAlpha = 255 - dimmingAlpha;
 
@@ -2336,7 +2336,7 @@ extern s8 sOcarinaInstrumentId;
 extern f32 AudioOcarina_BendPitchTwoSemitones(s8 bendIndex);
 
 // @recomp Patch the function in order to read DPad inputs for the ocarina as well as CButton inputs. 
-void AudioOcarina_PlayControllerInput(u8 isOcarinaSfxSuppressedWhenCancelled) {
+RECOMP_PATCH void AudioOcarina_PlayControllerInput(u8 isOcarinaSfxSuppressedWhenCancelled) {
     u32 ocarinaBtnsHeld;
 
     // Prevents two different ocarina notes from being played on two consecutive frames
@@ -2453,7 +2453,7 @@ extern void AudioOcarina_CheckIfStartedSong(void);
 extern void AudioOcarina_UpdateCurOcarinaSong(void);
 
 // @recomp Patch the L button check (for free ocarina playing) to account for DPad ocarina.
-void AudioOcarina_CheckSongsWithoutMusicStaff(void) {
+RECOMP_PATCH void AudioOcarina_CheckSongsWithoutMusicStaff(void) {
     u32 pitch;
     u8 ocarinaStaffPlayingPosStart;
     u8 songIndex;
@@ -2528,7 +2528,7 @@ extern bool get_analog_cam_active();
 extern void skip_analog_cam_once();
 
 // @recomp Updates yaw while inside of deku flower.
-void func_80855F9C(PlayState* play, Player* this) {
+RECOMP_PATCH void func_80855F9C(PlayState* play, Player* this) {
     f32 speedTarget;
     s16 yawTarget;
 
@@ -2553,7 +2553,7 @@ extern void Player_Action_4(Player* this, PlayState* play);
 extern s32 Player_SetAction(PlayState* play, Player* this, PlayerActionFunc actionFunc, s32 arg3);
 extern LinkAnimationHeader gPlayerAnim_pg_maru_change;
 
-s32 func_80857950(PlayState* play, Player* this) {
+RECOMP_PATCH s32 func_80857950(PlayState* play, Player* this) {
     // @recomp track if newly going from non-spike roll to spike roll (spike rolling when this->unk_B86[1] == 1)
     static bool wasOff = true;
     bool isOff = this->unk_B86[1] == 0;
@@ -2597,7 +2597,7 @@ extern void func_8082DC38(Player* this);
 extern void func_80836A5C(Player* this, PlayState* play);
 
 // @recomp Patch the shielding function to respect the aiming axis inversion setting.
-void Player_Action_18(Player* this, PlayState* play) {
+RECOMP_PATCH void Player_Action_18(Player* this, PlayState* play) {
     func_80832F24(this);
 
     if (this->transformation == PLAYER_FORM_GORON) {

--- a/patches/input_latency.c
+++ b/patches/input_latency.c
@@ -34,7 +34,7 @@ typedef enum {
     /* 2 */ VOICE_INIT_SUCCESS // voice initialized
 } VoiceInitStatus;
 
-void PadMgr_HandleRetrace(void) {
+RECOMP_PATCH void PadMgr_HandleRetrace(void) {
     // Execute rumble callback
     if (sPadMgrInstance->rumbleRetraceCallback != NULL) {
         sPadMgrInstance->rumbleRetraceCallback(sPadMgrInstance->rumbleRetraceArg);
@@ -113,7 +113,7 @@ void poll_inputs(void) {
 }
 
 // @recomp Patched to do the actual input polling.
-void PadMgr_GetInput(Input* inputs, s32 gameRequest) {
+RECOMP_PATCH void PadMgr_GetInput(Input* inputs, s32 gameRequest) {
     // @recomp Do an actual poll if gameRequest is true.
     if (gameRequest) {
         poll_inputs();
@@ -126,7 +126,7 @@ void PadMgr_GetInput(Input* inputs, s32 gameRequest) {
 }
 
 // @recomp Just call PadMgr_GetInput.
-void PadMgr_GetInput2(Input* inputs, s32 gameRequest) {
+RECOMP_PATCH void PadMgr_GetInput2(Input* inputs, s32 gameRequest) {
     PadMgr_GetInput(inputs, gameRequest);
 }
 
@@ -138,7 +138,7 @@ void* osViGetCurrentFramebuffer_recomp();
 OSMesgQueue *rdp_queue_ptr = NULL;
 
 // @recomp Immediately sends the graphics task instead of queueing it in the scheduler.
-void Graph_TaskSet00(GraphicsContext* gfxCtx, GameState* gameState) {
+RECOMP_PATCH void Graph_TaskSet00(GraphicsContext* gfxCtx, GameState* gameState) {
     static s32 retryCount = 10;
     static s32 cfbIdx = 0;
     OSTask_t* task = &gfxCtx->task.list.t;
@@ -271,7 +271,7 @@ extern VisZbuf sGameVisZbuf;
 extern VisMono sGameVisMono;
 extern ViMode sGameViMode;
 
-void GameState_Destroy(GameState* gameState) {
+RECOMP_PATCH void GameState_Destroy(GameState* gameState) {
     AudioMgr_StopAllSfxExceptSystem();
     Audio_Update();
 

--- a/patches/item_transform_tagging.c
+++ b/patches/item_transform_tagging.c
@@ -16,7 +16,7 @@ extern Gfx gHookshotChainDL[];
 
 void ArmsHook_Shoot(ArmsHook* this, PlayState* play);
 
-void ArmsHook_Draw(Actor* thisx, PlayState* play) {
+RECOMP_PATCH void ArmsHook_Draw(Actor* thisx, PlayState* play) {
     ArmsHook* this = THIS;
     f32 f0;
     Player* player = GET_PLAYER(play);
@@ -73,7 +73,7 @@ void ArmsHook_Draw(Actor* thisx, PlayState* play) {
 #undef THIS
 
 extern Gfx gHookshotReticleDL[];
-void Player_DrawHookshotReticle(PlayState* play, Player* player, f32 hookshotDistance) {
+RECOMP_PATCH void Player_DrawHookshotReticle(PlayState* play, Player* player, f32 hookshotDistance) {
     static Vec3f D_801C094C = { -500.0f, -100.0f, 0.0f };
     CollisionPoly* poly;
     s32 bgId;
@@ -143,7 +143,7 @@ Gfx bowstring_end_hook_dl[] = {
     gsSPEndDisplayList(),
 };
 
-void Player_DrawGameplay(PlayState* play, Player* this, s32 lod, Gfx* cullDList,
+RECOMP_PATCH void Player_DrawGameplay(PlayState* play, Player* this, s32 lod, Gfx* cullDList,
                          OverrideLimbDrawFlex overrideLimbDraw) {
     OPEN_DISPS(play->state.gfxCtx);
 

--- a/patches/ocarina_effect_patches.c
+++ b/patches/ocarina_effect_patches.c
@@ -1030,7 +1030,7 @@ void set_ocarina_vertex_alphas(Vtx* verts, s32 count, u8 alpha) {
 
 extern Gfx sSongOfTimeFrustumMaterialDL[];
 
-void OceffWipe_Draw(Actor* thisx, PlayState* play) {
+RECOMP_PATCH void OceffWipe_Draw(Actor* thisx, PlayState* play) {
     u32 scroll = play->state.frames & 0xFF;
     OceffWipe* this = (OceffWipe*)thisx;
     f32 z;
@@ -1098,7 +1098,7 @@ void OceffWipe_Draw(Actor* thisx, PlayState* play) {
 
 extern Gfx sEponaSongFrustumMaterialDL[];
 
-void OceffWipe2_Draw(Actor* thisx, PlayState* play) {
+RECOMP_PATCH void OceffWipe2_Draw(Actor* thisx, PlayState* play) {
     u32 scroll = play->state.frames & 0xFF;
     OceffWipe2* this = (OceffWipe2*)thisx;
     f32 z;
@@ -1152,7 +1152,7 @@ void OceffWipe2_Draw(Actor* thisx, PlayState* play) {
 
 extern Gfx sSariaSongFrustrumMaterialDL[];
 
-void OceffWipe3_Draw(Actor* thisx, PlayState* play) {
+RECOMP_PATCH void OceffWipe3_Draw(Actor* thisx, PlayState* play) {
     u32 scroll = play->state.frames & 0xFFF;
     OceffWipe3* this = (OceffWipe3*)thisx;
     f32 z;
@@ -1207,7 +1207,7 @@ extern Gfx sScarecrowSongUnusedMaterialDL[];
 extern Gfx sScarecrowSongMaterialDL[];
 extern Gfx sScarecrowSongModelDL[];
 
-void OceffWipe4_Draw(Actor* thisx, PlayState* play) {
+RECOMP_PATCH void OceffWipe4_Draw(Actor* thisx, PlayState* play) {
     u32 scroll = play->state.frames & 0xFFF;
     OceffWipe4* this = (OceffWipe4*)thisx;
     f32 z;
@@ -1273,7 +1273,7 @@ static u8 sEnvColors[] = {
 extern Gfx gOceff5DL[];
 extern AnimatedMaterial gOceff5TexAnim[];
 
-void OceffWipe5_Draw(Actor* thisx, PlayState* play) {
+RECOMP_PATCH void OceffWipe5_Draw(Actor* thisx, PlayState* play) {
     OceffWipe5* this = (OceffWipe5*)thisx;
     f32 z;
     s32 pad;
@@ -1342,7 +1342,7 @@ void OceffWipe5_Draw(Actor* thisx, PlayState* play) {
 extern Gfx gOceff6DL[];
 extern AnimatedMaterial ovl_Oceff_Wipe6_Matanimheader_000338[];
 
-void OceffWipe6_Draw(Actor* thisx, PlayState* play) {
+RECOMP_PATCH void OceffWipe6_Draw(Actor* thisx, PlayState* play) {
     OceffWipe6* this = (OceffWipe6*)thisx;
     f32 z;
     u8 alpha;
@@ -1394,7 +1394,7 @@ void OceffWipe6_Draw(Actor* thisx, PlayState* play) {
 extern Gfx sSongOfHealingEffectFrustumDL[];
 extern AnimatedMaterial sSongofHealingEffectTexAnim[];
 
-void OceffWipe7_Draw(Actor* thisx, PlayState* play) {
+RECOMP_PATCH void OceffWipe7_Draw(Actor* thisx, PlayState* play) {
     OceffWipe7* this = (OceffWipe7*)thisx;
     f32 z;
     u8 alpha;
@@ -1445,7 +1445,7 @@ extern AnimatedMaterial object_stk2_Matanimheader_009F60[];
 
 // @recomp Patch the Skull Kid curse effect as well, which works similarly to the ocarina effects.
 // In this case, the patch also includes effect transform tagging patches.
-void EffStk_Draw(Actor* thisx, PlayState* play) {
+RECOMP_PATCH void EffStk_Draw(Actor* thisx, PlayState* play) {
     EffStk* this = (EffStk*)thisx;
     s32 pad;
     Camera* activeCam = GET_ACTIVE_CAM(play);

--- a/patches/options.c
+++ b/patches/options.c
@@ -65,11 +65,11 @@ void FileSelect_DrawFileInfo(GameState *thisx, s16 fileIndex);
 void FileSelect_SplitNumber(u16 value, u16 *hundreds, u16 *tens, u16 *ones);
 
 // @recomp The options button is now the quit button, so close recomp instead of opening the options.
-void FileSelect_RotateToOptions(GameState* thisx) {
+RECOMP_PATCH void FileSelect_RotateToOptions(GameState* thisx) {
     recomp_exit();
 }
 
-void FileSelect_Init(GameState* thisx) {
+RECOMP_PATCH void FileSelect_Init(GameState* thisx) {
     s32 pad;
     FileSelectState* this = (FileSelectState*)thisx;
     size_t size;
@@ -109,7 +109,7 @@ void FileSelect_Init(GameState* thisx) {
 }
 
 
-void FileSelect_SetWindowContentVtx(GameState *thisx) {
+RECOMP_PATCH void FileSelect_SetWindowContentVtx(GameState *thisx) {
     FileSelectState *this = (FileSelectState *)thisx;
     u16 vtxId;
     s16 j;
@@ -786,7 +786,7 @@ void FileSelect_SetWindowContentVtx(GameState *thisx) {
  * Draw most window contents including buttons, labels, and icons.
  * Does not include anything from the keyboard and settings windows.
  */
-void FileSelect_DrawWindowContents(GameState *thisx) {
+RECOMP_PATCH void FileSelect_DrawWindowContents(GameState *thisx) {
     FileSelectState *this = (FileSelectState *)thisx;
     s16 fileIndex;
     s16 temp;
@@ -991,7 +991,7 @@ void FileSelect_DrawWindowContents(GameState *thisx) {
     CLOSE_DISPS(this->state.gfxCtx);
 }
 
-void FileSelect_ConfirmFile(GameState *thisx) {
+RECOMP_PATCH void FileSelect_ConfirmFile(GameState *thisx) {
     FileSelectState *this = (FileSelectState *)thisx;
     Input *input = CONTROLLER1(&this->state);
 
@@ -1040,7 +1040,7 @@ void FileSelect_ConfirmFile(GameState *thisx) {
  * Load the save for the appropriate file and start the game.
  * Update function for `SM_LOAD_GAME`
  */
-void FileSelect_LoadGame(GameState* thisx) {
+RECOMP_PATCH void FileSelect_LoadGame(GameState* thisx) {
     FileSelectState* this = (FileSelectState*)thisx;
     u16 i;
 

--- a/patches/particle_transform_tagging.c
+++ b/patches/particle_transform_tagging.c
@@ -10,7 +10,7 @@ extern EffectSsInfo sEffectSsInfo;
 u8 particle_reset_list[MAX_PARTICLES];
 
 // @recomp Patched to track that the particle has been reset.
-void EffectSS_ResetEntry(EffectSs* particle) {
+RECOMP_PATCH void EffectSS_ResetEntry(EffectSs* particle) {
     u32 i;
 
     particle->type = EFFECT_SS_MAX;
@@ -39,7 +39,7 @@ void EffectSS_ResetEntry(EffectSs* particle) {
 }
 
 // @recomp Check numEntries to be sure enough space has been allocated for tracking particle statuses.
-void EffectSS_Init(PlayState* play, s32 numEntries) {
+RECOMP_PATCH void EffectSS_Init(PlayState* play, s32 numEntries) {
     u32 i;
     EffectSs* effectsSs;
     EffectSsOverlay* overlay;
@@ -66,7 +66,7 @@ void EffectSS_Init(PlayState* play, s32 numEntries) {
 }
 
 // @recomp Add transform tags to particles
-void EffectSS_DrawParticle(PlayState* play, s32 index) {
+RECOMP_PATCH void EffectSS_DrawParticle(PlayState* play, s32 index) {
     EffectSs* entry = &sEffectSsInfo.dataTable[index];
 
     OPEN_DISPS(play->state.gfxCtx);
@@ -164,7 +164,7 @@ void func_80B22FA8_patched(Actor* thisx, EnHanabiStruct* arg0, PlayState* play2)
 }
 
 // @recomp Patched to call a custom version of a vanilla function.
-void EnHanabi_Draw(Actor* thisx, PlayState* play) {
+RECOMP_PATCH void EnHanabi_Draw(Actor* thisx, PlayState* play) {
     EnHanabi* this = (EnHanabi*)thisx;
 
     Matrix_Push();
@@ -176,7 +176,7 @@ void EnHanabi_Draw(Actor* thisx, PlayState* play) {
 Vec3f kankyo_prev_pos_base[DEMOKANKYO_EFFECT_COUNT] = {0};
 
 // @recomp Patched to draw the lost woods particles outside the 4:3 region and tag their transforms.
-void DemoKakyo_DrawLostWoodsSparkle(Actor* thisx, PlayState* play2) {
+RECOMP_PATCH void DemoKakyo_DrawLostWoodsSparkle(Actor* thisx, PlayState* play2) {
     PlayState* play = play2;
     DemoKankyo* this = (DemoKankyo*)thisx;
     s16 i;
@@ -286,7 +286,7 @@ extern Gfx gBubbleDL[];
 extern Gfx gLightOrbModelDL[];
 
 // @recomp Patched to draw the lost woods particles outside the 4:3 region and tag their transforms.
-void DemoKankyo_DrawMoonAndGiant(Actor* thisx, PlayState* play2) {
+RECOMP_PATCH void DemoKankyo_DrawMoonAndGiant(Actor* thisx, PlayState* play2) {
     PlayState* play = play2;
     DemoKankyo* this = (DemoKankyo*)thisx;
     s16 i;
@@ -386,7 +386,7 @@ static Vec3f D_80A5AFB0 = { 0.0f, 0.0f, 0.0f };
 #define WATER_EFFECT_RESPAWNED(ptr) (&(ptr)->unk_01)[1]
 
 // @recomp Mark respawned water effect particles so they can be skipped for the first frame.
-void func_80A599E8(EnWaterEffect* this, Vec3f* arg1, u8 arg2) {
+RECOMP_PATCH void func_80A599E8(EnWaterEffect* this, Vec3f* arg1, u8 arg2) {
     s16 i;
     EnWaterEffectStruct* ptr = &this->unk_144[0];
 
@@ -433,7 +433,7 @@ extern Gfx object_water_effect_DL_0043E8[];
 extern Gfx gameplay_keep_DL_06AB30[];
 
 // @recomp Tag the transforms for falling fire rocks.
-void func_80A5A184(Actor* thisx, PlayState* play2) {
+RECOMP_PATCH void func_80A5A184(Actor* thisx, PlayState* play2) {
     PlayState* play = play2;
     EnWaterEffect* this = (EnWaterEffect*)thisx;
     GraphicsContext* gfxCtx = play->state.gfxCtx;

--- a/patches/patches.h
+++ b/patches/patches.h
@@ -1,6 +1,10 @@
 #ifndef __PATCHES_H__
 #define __PATCHES_H__
 
+#define RECOMP_EXPORT __attribute__((section(".recomp_export")))
+#define RECOMP_PATCH __attribute__((section(".recomp_patch")))
+#define RECOMP_FORCE_PATCH __attribute__((section(".recomp_force_patch")))
+
 // TODO fix renaming symbols in patch recompilation
 #define osCreateMesgQueue osCreateMesgQueue_recomp
 #define osRecvMesg osRecvMesg_recomp

--- a/patches/patches.ld
+++ b/patches/patches.ld
@@ -7,12 +7,14 @@ MEMORY {
 }
 
 SECTIONS {
-    .ctors         : { *(.ctors*) *(.init_array*) } >extram AT >rom
-    .dtors         : { *(.dtors*)                 } >extram AT >rom
-    .text          : { *(.text*)                  } >extram AT >rom
-    .rodata        : { *(.rodata*)                } >extram AT >rom
-    .data          : { *(.data*)                  } >extram AT >rom
-    .bss  (NOLOAD) : { *(.bss*)  *(COMMON)        } >extram
+    .ctors         : { *(.ctors*) *(.init_array*)                } >extram AT >rom
+    .dtors         : { *(.dtors*)                                } >extram AT >rom
+    .text          : { *(.text*)                                 } >extram AT >rom
+    .recomp_patch  : { *(.recomp_patch*) *(.recomp_force_patch*) } >extram AT >rom
+    .recomp_export : { *(.recomp_export*)                        } >extram AT >rom
+    .rodata        : { *(.rodata*)                               } >extram AT >rom
+    .data          : { *(.data*)                                 } >extram AT >rom
+    .bss  (NOLOAD) : { *(.bss*)  *(COMMON)                       } >extram
     ASSERT(. < RAMBASE + EXTRA_RAM_SIZE, "Maxed out recomp extra ram")
     
     .reloc 0 : { *(.reloc*) }

--- a/patches/play_patches.c
+++ b/patches/play_patches.c
@@ -9,7 +9,7 @@ void controls_play_update(PlayState* play) {
 }
 
 // @recomp Patched to add hooks for various added functionality.
-void Play_Main(GameState* thisx) {
+RECOMP_PATCH void Play_Main(GameState* thisx) {
     static Input* prevInput = NULL;
     PlayState* this = (PlayState*)thisx;
 
@@ -54,7 +54,7 @@ void Play_Main(GameState* thisx) {
 }
 
 // @recomp Patched to add load a hook for loading rooms.
-s32 Room_HandleLoadCallbacks(PlayState* play, RoomContext* roomCtx) {
+RECOMP_PATCH s32 Room_HandleLoadCallbacks(PlayState* play, RoomContext* roomCtx) {
     if (roomCtx->status == 1) {
         if (osRecvMesg(&roomCtx->loadQueue, NULL, OS_MESG_NOBLOCK) == 0) {
             roomCtx->status = 0;

--- a/patches/required_patches.c
+++ b/patches/required_patches.c
@@ -8,7 +8,7 @@ void Main_InitScreen(void);
 
 
 // @recomp Patched to load the code segment in the recomp runtime.
-void Main_Init(void) {
+RECOMP_PATCH void Main_Init(void) {
     DmaRequest dmaReq;
     OSMesgQueue mq;
     OSMesg msg[1];
@@ -36,7 +36,7 @@ void Main_Init(void) {
 void Overlay_Relocate(void* allocatedRamAddr, OverlayRelocationSection* ovlRelocs, uintptr_t vramStart);
 
 // @recomp Patched to load the overlay in the recomp runtime.
-size_t Overlay_Load(uintptr_t vromStart, uintptr_t vromEnd, void* ramStart, void* ramEnd, void* allocatedRamAddr) {
+RECOMP_PATCH size_t Overlay_Load(uintptr_t vromStart, uintptr_t vromEnd, void* ramStart, void* ramEnd, void* allocatedRamAddr) {
     uintptr_t vramStart = (uintptr_t)ramStart;
     uintptr_t vramEnd = (uintptr_t)ramEnd;
     s32 size = vromEnd - vromStart;

--- a/patches/save_patches.c
+++ b/patches/save_patches.c
@@ -8,7 +8,7 @@ s32 SysFlashrom_IsInit(void);
 void Sleep_Msec(u32 ms);
 
 // @recomp Patched to not wait a hardcoded amount of time for the save to complete.
-void Sram_UpdateWriteToFlashDefault(SramContext* sramCtx) {
+RECOMP_PATCH void Sram_UpdateWriteToFlashDefault(SramContext* sramCtx) {
     if (sramCtx->status == 2) {
         if (SysFlashrom_IsBusy() != 0) {          // if task running
             if (SysFlashrom_AwaitResult() == 0) { // wait for task done
@@ -26,7 +26,7 @@ void Sram_UpdateWriteToFlashDefault(SramContext* sramCtx) {
 }
 
 // @recomp Patched to not wait a hardcoded amount of time for the save to complete.
-void Sram_UpdateWriteToFlashOwlSave(SramContext* sramCtx) {
+RECOMP_PATCH void Sram_UpdateWriteToFlashOwlSave(SramContext* sramCtx) {
     if (sramCtx->status == 7) {
         if (SysFlashrom_IsBusy() != 0) {          // Is task running
             if (SysFlashrom_AwaitResult() == 0) { // Wait for task done

--- a/patches/skip_sos.c
+++ b/patches/skip_sos.c
@@ -7,7 +7,7 @@
 void func_80AF118C(PlayState* play, OwlWarpFeather* feathers, EnTest7* this, s32 arg3, s32 arg4); // EnTest7_UpdateFeathers
 void func_80AF2350(EnTest7* this, PlayState* play); // EnTest7_WarpCsWarp
 
-void EnTest7_Update(Actor* thisx, PlayState* play) {
+RECOMP_PATCH void EnTest7_Update(Actor* thisx, PlayState* play) {
     EnTest7* this = THIS;
 
     this->actionFunc(this, play);

--- a/patches/sky_transform_tagging.c
+++ b/patches/sky_transform_tagging.c
@@ -5,7 +5,7 @@
 
 extern Mtx* sSkyboxDrawMatrix;
 
-void Skybox_Draw(SkyboxContext* skyboxCtx, GraphicsContext* gfxCtx, s16 skyboxId, s16 blend, f32 x, f32 y, f32 z) {
+RECOMP_PATCH void Skybox_Draw(SkyboxContext* skyboxCtx, GraphicsContext* gfxCtx, s16 skyboxId, s16 blend, f32 x, f32 y, f32 z) {
     OPEN_DISPS(gfxCtx);
 
     Gfx_SetupDL40_Opa(gfxCtx);
@@ -112,7 +112,7 @@ f32 view_aspect_ratio(View* view) {
 }
 
 // @recomp Patched to set up the RSP for drawing stars with ortho rects and tag star transforms.
-void Environment_DrawSkyboxStarsImpl(PlayState* play, Gfx** gfxP) {
+RECOMP_PATCH void Environment_DrawSkyboxStarsImpl(PlayState* play, Gfx** gfxP) {
     static const Vec3s D_801DD880[] = {
         { 0x0384, 0x2328, 0xD508 }, { 0x09C4, 0x2328, 0xDA1C }, { 0x0E74, 0x22D8, 0xDA1C }, { 0x1450, 0x2468, 0xD8F0 },
         { 0x1C84, 0x28A0, 0xCBA8 }, { 0x1F40, 0x2134, 0xD8F0 }, { 0x1F40, 0x28A0, 0xDAE4 }, { 0xE4A8, 0x4A38, 0x4A38 },

--- a/patches/song_transform_tagging.c
+++ b/patches/song_transform_tagging.c
@@ -15,7 +15,7 @@ s32 func_80AF31D0(PlayState* play, SkeletonInfo* skeletonInfo, s32 limbIndex, Gf
 extern AnimatedMaterial gSoaringWarpCsWindCapsuleTexAnim;
 extern Gfx gSoaringWarpCsWindCapsuleDL[];
 
-void EnTest7_Draw(Actor* thisx, PlayState* play) {
+RECOMP_PATCH void EnTest7_Draw(Actor* thisx, PlayState* play) {
     s32 pad[2];
     EnTest7* this = (EnTest7*)thisx;
     s32 sp40;
@@ -104,7 +104,7 @@ extern SoTCsAmmoDrops sSoTCsAmmoDrops[12];
 /**
  * Draws clocks in a double spiral above and below player
  */
-void EnTest6_DrawThreeDayResetSoTCutscene(EnTest6* this, PlayState* play) {
+RECOMP_PATCH void EnTest6_DrawThreeDayResetSoTCutscene(EnTest6* this, PlayState* play) {
     s16 clock1Yaw;
     s16 clock2Yaw;
     s16 angle;

--- a/patches/sound_patches.c
+++ b/patches/sound_patches.c
@@ -17,7 +17,7 @@ bool is_bgm_player(u8 player_index) {
 /**
  * Update different commands and requests for active sequences
  */
-void AudioSeq_UpdateActiveSequences(void) {
+RECOMP_PATCH void AudioSeq_UpdateActiveSequences(void) {
     u32 tempoCmd;
     u16 tempoPrev;
     u16 seqId;
@@ -338,7 +338,7 @@ void AudioSeq_UpdateActiveSequences(void) {
 }
 
 // @recomp Patched to add the ability to turn off low health beeps.
-void LifeMeter_UpdateSizeAndBeep(PlayState* play) {
+RECOMP_PATCH void LifeMeter_UpdateSizeAndBeep(PlayState* play) {
     InterfaceContext* interfaceCtx = &play->interfaceCtx;
 
     if (interfaceCtx->lifeSizeChangeDirection != 0) {

--- a/patches/specific_actor_transform_tagging.c
+++ b/patches/specific_actor_transform_tagging.c
@@ -30,7 +30,7 @@ extern Gfx gEffWaterRippleDL[];
 u8 special_effect_reset_states[MAX_SPECIAL_EFFECTS];
 
 // @recomp Tag Wart's bubbles
-void EnTanron2_Draw(Actor* thisx, PlayState* play2) {
+RECOMP_PATCH void EnTanron2_Draw(Actor* thisx, PlayState* play2) {
     PlayState* play = play2;
     s32 i;
     s32 j;
@@ -153,7 +153,7 @@ void EnTanron2_Draw(Actor* thisx, PlayState* play2) {
 }
 
 // @recomp Track this effect's reset state.
-void Boss03_SpawnEffectWetSpot(PlayState* play, Vec3f* pos) {
+RECOMP_PATCH void Boss03_SpawnEffectWetSpot(PlayState* play, Vec3f* pos) {
     s16 i;
     GyorgEffect* eff = play->specialEffects;
 
@@ -177,7 +177,7 @@ void Boss03_SpawnEffectWetSpot(PlayState* play, Vec3f* pos) {
 }
 
 // @recomp Track this effect's reset state.
-void Boss03_SpawnEffectDroplet(PlayState* play, Vec3f* pos) {
+RECOMP_PATCH void Boss03_SpawnEffectDroplet(PlayState* play, Vec3f* pos) {
     s16 i;
     GyorgEffect* eff = play->specialEffects;
 
@@ -204,7 +204,7 @@ void Boss03_SpawnEffectDroplet(PlayState* play, Vec3f* pos) {
 }
 
 // @recomp Track this effect's reset state.
-void Boss03_SpawnEffectSplash(PlayState* play, Vec3f* pos, Vec3f* velocity) {
+RECOMP_PATCH void Boss03_SpawnEffectSplash(PlayState* play, Vec3f* pos, Vec3f* velocity) {
     Vec3f accel = { 0.0f, -1.0f, 0.0f };
     f32 temp_f2;
     GyorgEffect* eff = play->specialEffects;
@@ -231,7 +231,7 @@ void Boss03_SpawnEffectSplash(PlayState* play, Vec3f* pos, Vec3f* velocity) {
 }
 
 // @recomp Track this effect's reset state.
-void Boss03_SpawnEffectBubble(PlayState* play, Vec3f* pos) {
+RECOMP_PATCH void Boss03_SpawnEffectBubble(PlayState* play, Vec3f* pos) {
     s16 i;
     GyorgEffect* eff = play->specialEffects;
 
@@ -261,7 +261,7 @@ extern u8 gEffDust1Tex[];
 void Boss03_SetObject(PlayState* play, s16 objectId);
 
 // @recomp Tag Gyorg's effects.
-void Boss03_DrawEffects(PlayState* play) {
+RECOMP_PATCH void Boss03_DrawEffects(PlayState* play) {
     u8 flag = false;
     s16 i;
     GraphicsContext* gfxCtx = play->state.gfxCtx;
@@ -410,7 +410,7 @@ extern Gfx object_water_effect_DL_000420[];
 extern Gfx object_water_effect_DL_000A48[];
 extern Gfx object_water_effect_DL_000CD8[];
 
-void func_80A5A6B8(Actor* thisx, PlayState* play2) {
+RECOMP_PATCH void func_80A5A6B8(Actor* thisx, PlayState* play2) {
     PlayState* play = play2;
     EnWaterEffect* this = (EnWaterEffect*)thisx;
     EnWaterEffectStruct* ptr = &this->unk_144[0];
@@ -547,7 +547,7 @@ void func_80A5A6B8(Actor* thisx, PlayState* play2) {
 }
 
 // @recomp Tag normal water effects.
-void EnWaterEffect_Draw(Actor* thisx, PlayState* play2) {
+RECOMP_PATCH void EnWaterEffect_Draw(Actor* thisx, PlayState* play2) {
     PlayState* play = play2;
     GraphicsContext* gfxCtx = play->state.gfxCtx;
     EnWaterEffect* this = (EnWaterEffect*)thisx;
@@ -641,7 +641,7 @@ extern Gfx gGohtStalactiteMaterialDL[];
 extern Gfx gGohtStalactiteModelDL[];
 
 // @recomp Tag Goht's rocks.
-void func_80B0C398(BossHakugin* this, PlayState* play) {
+RECOMP_PATCH void func_80B0C398(BossHakugin* this, PlayState* play) {
     BossHakuginEffect* effect;
     s32 i;
 
@@ -722,7 +722,7 @@ void EnOsn_HandleCsAction(EnOsn* this, PlayState* play);
 void EnOsn_Idle(EnOsn* this, PlayState* play);
 
 // @recomp Patched to skip interpolation when the Happy Mask Salesman changes animations.
-void EnOsn_ChooseAction(EnOsn* this, PlayState* play) {
+RECOMP_PATCH void EnOsn_ChooseAction(EnOsn* this, PlayState* play) {
     u32 isSwitchFlagSet = Flags_GetSwitch(play, 0);
 
     this->csId = this->actor.csId;
@@ -743,7 +743,7 @@ void EnOsn_LookFromMask(EnOsn* this);
 void EnOsn_FadeOut(EnOsn* this);
 
 // @recomp Patched to skip interpolation when the Happy Mask Salesman changes animations.
-void EnOsn_HandleCsAction(EnOsn* this, PlayState* play) {
+RECOMP_PATCH void EnOsn_HandleCsAction(EnOsn* this, PlayState* play) {
     u8 pad;
     s32 cueChannel;
 
@@ -880,7 +880,7 @@ void EnOsn_HandleCsAction(EnOsn* this, PlayState* play) {
 }
 
 // @recomp Patched to tag this actor's draws using linear order matching.
-void EnFall2_Draw(Actor* thisx, PlayState* play) {
+RECOMP_PATCH void EnFall2_Draw(Actor* thisx, PlayState* play) {
     s32 pad;
     EnFall2* this = (EnFall2*)thisx;
     Mtx* mtx;
@@ -909,7 +909,7 @@ void EnFall2_Draw(Actor* thisx, PlayState* play) {
 }
 
 // @recomp Skip interpolation on item pickups the frame they're collected.
-void func_800A6A40(EnItem00* this, PlayState* play) {
+RECOMP_PATCH void func_800A6A40(EnItem00* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
     if (this->getItemId != GI_NONE) {
@@ -952,7 +952,7 @@ extern Vtx ovl_Obj_Entotu_Vtx_000D10[7];
 extern Gfx object_f53_obj_DL_001C00[];
 
 // @recomp Skip rotation interpolation for the Clock Town chimney's smoke when the camera skips interolation.
-void func_80A34B28(ObjEntotu* this, PlayState* play) {
+RECOMP_PATCH void func_80A34B28(ObjEntotu* this, PlayState* play) {
     u8 sp57;
     u8 sp56;
     s32 i;
@@ -1002,7 +1002,7 @@ void func_80A34B28(ObjEntotu* this, PlayState* play) {
 extern Gfx object_f53_obj_DL_000158[];
 
 // @recomp Skip rotation interpolation for the Clock Town chimney when the camera skips interolation.
-void func_80A34A44(ObjEntotu* this, PlayState* play) {
+RECOMP_PATCH void func_80A34A44(ObjEntotu* this, PlayState* play) {
     Matrix_Translate(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z, MTXMODE_NEW);
     this->actor.shape.rot.y = BINANG_ROT180(Camera_GetCamDirYaw(GET_ACTIVE_CAM(play)));
     Matrix_RotateYS(this->actor.shape.rot.y, MTXMODE_APPLY);
@@ -1032,7 +1032,7 @@ void func_80A34A44(ObjEntotu* this, PlayState* play) {
 void Environment_DrawRainImpl(PlayState* play, View* view, GraphicsContext* gfxCtx);
 
 // @recomp Skip interpolation for the splashes that raindrops make.
-void Environment_DrawRain(PlayState* play, View* view, GraphicsContext* gfxCtx) {
+RECOMP_PATCH void Environment_DrawRain(PlayState* play, View* view, GraphicsContext* gfxCtx) {
     if (!(GET_ACTIVE_CAM(play)->stateFlags & CAM_STATE_UNDERWATER) &&
         (play->envCtx.precipitation[PRECIP_SNOW_CUR] == 0)) {
         
@@ -1058,7 +1058,7 @@ void Environment_DrawRain(PlayState* play, View* view, GraphicsContext* gfxCtx) 
 }
 
 // @recomp Skip interpolation on the boulders in the path to Snowhead and the path to Ikana Canyon when they teleport back to their home position.
-void func_8093EE64(EnGoroiwa* this, s32 arg1) {
+RECOMP_PATCH void func_8093EE64(EnGoroiwa* this, s32 arg1) {
     Vec3s* temp_v0 = &this->pathPoints[arg1];
 
     this->actor.world.pos.x = temp_v0->x;
@@ -1075,7 +1075,7 @@ extern Gfx object_twig_DL_001C38[];
 extern Gfx object_twig_DL_0014C8[];
 
 // @recomp Skip interpolation on the rotation for the beaver race rings in order to retain the intended animation look.
-void EnTwig_Draw(Actor* thisx, PlayState* play) {
+RECOMP_PATCH void EnTwig_Draw(Actor* thisx, PlayState* play) {
     EnTwig* this = (EnTwig*)thisx;
 
     switch (this->unk_160) {
@@ -1101,7 +1101,7 @@ extern Gfx gEffFire1DL[];
 #define HONOTRAP_EXTRA_BYTE_1(flameGroup) (&(flameGroup)->flameList[0].isDrawn)[1]
 #define HONOTRAP_EXTRA_BYTE_2(flameGroup) (&(flameGroup)->flameList[1].isDrawn)[1]
 
-void EnHonotrap_FlameGroup(EnHonotrap* this, PlayState* play) {
+RECOMP_PATCH void EnHonotrap_FlameGroup(EnHonotrap* this, PlayState* play) {
     s32 i;
     EnHonotrapFlameGroup* flameGroup = &this->flameGroup;
     f32 var_fs0;
@@ -1203,7 +1203,7 @@ void EnHonotrap_FlameGroup(EnHonotrap* this, PlayState* play) {
 
 
 // @recomp Patched to tag the flames that come out of fire eyes.
-void EnHonotrap_DrawFlameGroup(Actor* thisx, PlayState* play) {
+RECOMP_PATCH void EnHonotrap_DrawFlameGroup(Actor* thisx, PlayState* play) {
     s32 pad;
     EnHonotrap* this = (EnHonotrap*)thisx;
     EnHonotrapFlameElement* flameElem;

--- a/patches/terrain_transform_tagging.c
+++ b/patches/terrain_transform_tagging.c
@@ -7,7 +7,7 @@ static Vec3f sZeroVec = { 0.0f, 0.0f, 0.0f };
 
 extern RoomDrawHandler sRoomDrawHandlers[];
 
-void Room_Draw(PlayState* play, Room* room, u32 flags) {
+RECOMP_PATCH void Room_Draw(PlayState* play, Room* room, u32 flags) {
     if (room->segment != NULL) {
         gSegments[3] = OS_K0_TO_PHYSICAL(room->segment);
         
@@ -51,7 +51,7 @@ extern Gfx gKeikokuDemoTallTreeStraightDL[];
 extern Gfx gKeikokuDemoTallTreeStraightEmptyDL[];
 
 // @recomp Tag the ground in the intro cutscene to not interpolate rotation.
-void DmOpstage_Draw(Actor* thisx, PlayState* play) {
+RECOMP_PATCH void DmOpstage_Draw(Actor* thisx, PlayState* play) {
     DmOpstage* this = (DmOpstage*)thisx;
 
     if (DMOPSTAGE_GET_TYPE(&this->dyna.actor) > DMOPSTAGE_TYPE_GROUND) {
@@ -130,7 +130,7 @@ extern s16 D_80AAAAC8;
 extern s16 D_80AAAACC;
 
 // @recomp Patched to enable vertex interpolation for the dynamic water as Woodfall temple rises from below the water.
-void DmChar01_Draw(Actor* thisx, PlayState* play) {
+RECOMP_PATCH void DmChar01_Draw(Actor* thisx, PlayState* play) {
     // @recomp Move function statics to externs so they still get reset on overlay load like normal.
     DmChar01* this = (DmChar01*)thisx;
     f32 temp_f12;

--- a/patches/ui_patches.c
+++ b/patches/ui_patches.c
@@ -22,7 +22,7 @@ typedef struct {
 BiggerGfxPool gBiggerGfxPools[2];
 
 // @recomp Use the bigger gfx pools and enable RT64 extended GBI mode.
-void Graph_SetNextGfxPool(GraphicsContext* gfxCtx) {
+RECOMP_PATCH void Graph_SetNextGfxPool(GraphicsContext* gfxCtx) {
     GfxPool* pool = &gGfxPools[gfxCtx->gfxPoolIdx % 2];
     BiggerGfxPool* bigger_pool = &gBiggerGfxPools[gfxCtx->gfxPoolIdx % 2];
 
@@ -85,7 +85,7 @@ extern int extra_vis;
  *  Run the game state logic, then finalize the gfx buffer
  *  and run the graphics task for this frame.
  */
-void Graph_ExecuteAndDraw(GraphicsContext* gfxCtx, GameState* gameState) {
+RECOMP_PATCH void Graph_ExecuteAndDraw(GraphicsContext* gfxCtx, GameState* gameState) {
     u32 problem;
 
     gameState->unk_A3 = 0;
@@ -238,7 +238,7 @@ void Interface_SetOrthoView(InterfaceContext* interfaceCtx);
 void Interface_SetVertices(PlayState* play);
 void Magic_DrawMeter(PlayState* play);
 
-void Interface_Draw(PlayState* play) {
+RECOMP_PATCH void Interface_Draw(PlayState* play) {
     s32 pad;
     InterfaceContext* interfaceCtx = &play->interfaceCtx;
     Player* player = GET_PLAYER(play);
@@ -756,7 +756,7 @@ extern u64 gArcheryScoreIconTex[];
 extern u16 sMinigameScoreDigits[];
 
 // @recomp Patched to draw the carrot icons with an extended gbi texrect so they don't inherit the current origin.
-void Interface_DrawMinigameIcons(PlayState* play) {
+RECOMP_PATCH void Interface_DrawMinigameIcons(PlayState* play) {
     InterfaceContext* interfaceCtx = &play->interfaceCtx;
     s16 i;
     s16 numDigitsDrawn;
@@ -881,7 +881,7 @@ extern s16 sTextboxTexHeight;
 extern u64 gOcarinaTrebleClefTex[];
 
 // @recomp Patch textboxes to use ortho tris with a matrix so they can be interpolated.
-void Message_DrawTextBox(PlayState* play, Gfx** gfxP) {
+RECOMP_PATCH void Message_DrawTextBox(PlayState* play, Gfx** gfxP) {
     MessageContext* msgCtx = &play->msgCtx;
     Gfx* gfx = *gfxP;
 
@@ -1018,7 +1018,7 @@ void View_SetScissor(Gfx** gfx, s32 ulx, s32 uly, s32 lrx, s32 lry);
 
 // @recomp Patched to not actually letterbox the scissor. The letterbox effect will be achieved by drawing an overlay on top instead, which
 // will get interpolated unlike a scissor.
-void View_ApplyLetterbox(View* view) {
+RECOMP_PATCH void View_ApplyLetterbox(View* view) {
     s32 letterboxY;
     s32 letterboxX;
     s32 pad1;
@@ -1085,7 +1085,7 @@ typedef struct {
 extern ShrinkWindow* sShrinkWindowPtr;
 
 // @recomp Replace the rects used to letterbox with ortho tris so they can be interpolated.
-void ShrinkWindow_Draw(GraphicsContext* gfxCtx) {
+RECOMP_PATCH void ShrinkWindow_Draw(GraphicsContext* gfxCtx) {
     Gfx* gfx;
     s8 letterboxSize = sShrinkWindowPtr->letterboxSize;
     s8 pillarboxSize = sShrinkWindowPtr->pillarboxSize;
@@ -1189,7 +1189,7 @@ extern u64 gSceneTitleCardGradientTex[];
 
 // @recomp Patch the scene title card (the one with purple background when entering a new scene) 
 // to not glitch out on the right edge, which is hidden by overscan on N64.
-void Message_DrawSceneTitleCard(PlayState* play, Gfx** gfxP) {
+RECOMP_PATCH void Message_DrawSceneTitleCard(PlayState* play, Gfx** gfxP) {
     MessageContext* msgCtx = &play->msgCtx;
     Gfx* gfx;
 

--- a/patches/ui_transform_tagging.c
+++ b/patches/ui_transform_tagging.c
@@ -56,7 +56,7 @@ extern TexturePtr sMaskPageBgTextures[];
 
 // @recomp Patched to set pageIndex to a dummy value when KaleidoScope_SetVertices is called to make it
 // allocate vertices for all pages at all times. This is simpler than patching KaleidoScope_SetVertices directly.
-void KaleidoScope_Draw(PlayState* play) {
+RECOMP_PATCH void KaleidoScope_Draw(PlayState* play) {
     s32 pad;
     PauseContext* pauseCtx = &play->pauseCtx;
     InterfaceContext* interfaceCtx = &play->interfaceCtx;
@@ -137,7 +137,7 @@ void KaleidoScope_Draw(PlayState* play) {
     CLOSE_DISPS(play->state.gfxCtx);
 }
 
-void KaleidoScope_DrawCursor(PlayState* play) {
+RECOMP_PATCH void KaleidoScope_DrawCursor(PlayState* play) {
     PauseContext* pauseCtx = &play->pauseCtx;
     s16 i;
 
@@ -219,7 +219,7 @@ extern s16 sPauseZRCursorAlpha; // 8082DA56 32899 -9642
  */
 
 // @recomp Patched to tag the matrix for interpolating the vertices of the Z button, R button, and name panel.
-void KaleidoScope_DrawInfoPanel(PlayState* play) {
+RECOMP_PATCH void KaleidoScope_DrawInfoPanel(PlayState* play) {
     static const s16 sPauseZRCursorColorTargets[][4] = {
         { 180, 210, 255, 220 },
         { 100, 100, 150, 220 },
@@ -587,7 +587,7 @@ void KaleidoScope_DrawInfoPanel(PlayState* play) {
 }
 
 // @recomp Patched to draw always all 4 pages and tag their matrices.
-void KaleidoScope_DrawPages(PlayState* play, GraphicsContext* gfxCtx) {
+RECOMP_PATCH void KaleidoScope_DrawPages(PlayState* play, GraphicsContext* gfxCtx) {
     static s16 sCursorColorTimer = 10;
     static s16 sCursorColorTargetIndex = 0;
     PauseContext* pauseCtx = &play->pauseCtx;


### PR DESCRIPTION
Strict mode makes the recompiler validate that functions marked as a patch are present in the reference symbols. It also makes the recompiler validate that functions _not_ marked as a patch are not in the reference symbols. Enabling this will allow updating the symbol files and decomp submodule without worrying about renamed functions causing patches to break.