### PR TITLE
Fix .recomp_patch section functions not getting loaded

### DIFF
--- a/src/main/register_patches.cpp
+++ b/src/main/register_patches.cpp
@@ -6,5 +6,5 @@
 #include "librecomp/game.hpp"
 
 void zelda64::register_patches() {
-    recomp::overlays::register_patches(mm_patches_bin, sizeof(mm_patches_bin), section_table);
+    recomp::overlays::register_patches(mm_patches_bin, sizeof(mm_patches_bin), section_table, ARRLEN(section_table));
 }


### PR DESCRIPTION
This fixes a crash caused by the Happy Mask Salesman's actor when entering the clock tower for the first time on a new file.