### PR TITLE
[DO NOT MERGE] re-spirv Experimental Branch.

### DIFF
--- a/src/main/rt64_render_context.cpp
+++ b/src/main/rt64_render_context.cpp
@@ -266,6 +266,9 @@ zelda64::renderer::RT64Context::RT64Context(uint8_t* rdram, ultramodern::rendere
     // Set the application's fullscreen state.
     app->setFullScreen(cur_config.wm_option == ultramodern::renderer::WindowMode::Fullscreen);
 
+    // Default to ubershaders being visible to visualize the shader compilation time.
+    app->workloadQueue->ubershadersVisible = true;
+
     // Check if the selected device actually supports MSAA sample positions and MSAA for for the formats that will be used
     // and downgrade the configuration accordingly.
     if (app->device->getCapabilities().sampleLocations) {


### PR DESCRIPTION
Ubershaders are red and visible by default to visualize the shader compilation times on Deck.

<!--- section:artifacts:start -->
### Build Artifacts
- [Zelda64Recompiled-Linux-ARM64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/1785930917.zip)
- [Zelda64Recompiled-Linux-ARM64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/1785933092.zip)
- [Zelda64Recompiled-AppImage-ARM64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/1785934040.zip)
- [Zelda64Recompiled-AppImage-ARM64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/1785936236.zip)
- [Zelda64Recompiled-Windows-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/1785941130.zip)
- [Zelda64Recompiled-Windows-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/1785943217.zip)
- [Zelda64Recompiled-AppImage-X64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/1785944815.zip)
- [Zelda64Recompiled-AppImage-X64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/1785944819.zip)
- [Zelda64Recompiled-Linux-X64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/1785944822.zip)
- [Zelda64Recompiled-Linux-X64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/1785944829.zip)
<!--- section:artifacts:end -->