### PR TITLE
Update Ubuntu build instructions

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -20,7 +20,7 @@ For Linux the instructions for Ubuntu are provided, but you can find the equival
 
 ```bash
 # For Ubuntu, simply run:
-sudo apt-get install cmake ninja-build libsdl2-dev libgtk-3-dev lld llvm clang-15
+sudo apt-get install cmake ninja-build libsdl2-dev libgtk-3-dev lld llvm clang
 ```
 
 ### Windows
@@ -65,7 +65,7 @@ On Windows, you can open the repository folder with Visual Studio, and you'll be
 If you prefer the command line or you're on a Unix platform you can build the project using CMake:
 
 ```bash
-cmake -S . -B build-cmake -DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_C_COMPILER=clang-15 -DPATCHES_C_COMPILER=clang-15 -G Ninja -DCMAKE_BUILD_TYPE=Release # or Debug if you want to debug
+cmake -S . -B build-cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -G Ninja -DCMAKE_BUILD_TYPE=Release # or Debug if you want to debug
 cmake --build build-cmake --target Zelda64Recompiled -j$(nproc) --config Release # or Debug
 ```
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -20,7 +20,7 @@ For Linux the instructions for Ubuntu are provided, but you can find the equival
 
 ```bash
 # For Ubuntu, simply run:
-sudo apt-get install cmake ninja libsdl2-dev libgtk-3-dev lld llvm clang-15
+sudo apt-get install cmake ninja-build libsdl2-dev libgtk-3-dev lld llvm clang-15
 ```
 
 ### Windows
@@ -65,7 +65,7 @@ On Windows, you can open the repository folder with Visual Studio, and you'll be
 If you prefer the command line or you're on a Unix platform you can build the project using CMake:
 
 ```bash
-cmake -S . -B build-cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -G Ninja -DCMAKE_BUILD_TYPE=Release # or Debug if you want to debug
+cmake -S . -B build-cmake -DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_C_COMPILER=clang-15 -DPATCHES_C_COMPILER=clang-15 -G Ninja -DCMAKE_BUILD_TYPE=Release # or Debug if you want to debug
 cmake --build build-cmake --target Zelda64Recompiled -j$(nproc) --config Release # or Debug
 ```
 


### PR DESCRIPTION
Current instructions to build in Ubuntu appear to be incorrect.

A package name needed to be updated for the apt-get command:
* Updated `ninja` to be `ninja-build`.

Some cmake variables needed to be set and/or updated in one of the example cmake commands:
* Updated `DCMAKE_CXX_COMPILER=clang++` to `DCMAKE_CXX_COMPILER=clang++-15`
* Updated `-DCMAKE_C_COMPILER=clang` to `-DCMAKE_C_COMPILER=clang-15`
* Added `-DPATCHES_C_COMPILER=clang-15`

I updated the instructions with what I've run in my local environment, but it might be worth updating instructions to be in line with what is currently done via the [validation Github action](https://github.com/Zelda64Recomp/Zelda64Recomp/blob/d99a84f04f6803a0df49383b6a05f4253a1b7c0a/.github/workflows/validate.yml#L90) instead. This workflow explicitly sets a few more cmake variables and uses clang-17 over clang-15.

<!--- section:artifacts:start -->
### Build Artifacts
- [Zelda64Recompiled-Linux-ARM64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2021000132.zip)
- [Zelda64Recompiled-AppImage-ARM64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2021000955.zip)
- [Zelda64Recompiled-Windows-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2021001115.zip)
- [Zelda64Recompiled-Linux-ARM64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2021002740.zip)
- [Zelda64Recompiled-Windows-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2021002959.zip)
- [Zelda64Recompiled-AppImage-ARM64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2021003920.zip)
- [Zelda64Recompiled-AppImage-X64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2021004172.zip)
- [Zelda64Recompiled-AppImage-X64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2021004173.zip)
- [Zelda64Recompiled-Linux-X64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2021004174.zip)
- [Zelda64Recompiled-Linux-X64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2021004175.zip)
<!--- section:artifacts:end -->