### PR TITLE
Add exports for fd anywhere and epona fix patches

### DIFF
--- a/patches/input.c
+++ b/patches/input.c
@@ -633,9 +633,8 @@ RECOMP_PATCH void Interface_UpdateButtonsPart1(PlayState* play) {
                                 Interface_LoadItemIconImpl(play, EQUIP_SLOT_B);
                             }
 
-                            // @recomp_use_export_var no_bow_epona_fix: If B item is a sword, don't disable the UI.
-                            if (!no_bow_epona_fix || (BUTTON_ITEM_EQUIP(CUR_FORM, EQUIP_SLOT_B) < ITEM_SWORD_KOKIRI ||
-                                BUTTON_ITEM_EQUIP(CUR_FORM, EQUIP_SLOT_B) > ITEM_SWORD_GILDED)) {
+                            // @recomp_use_export_var no_bow_epona_fix: If riding Epona, don't disable the UI.
+                            if (!no_bow_epona_fix || (player->stateFlags1 & PLAYER_STATE1_800000) == 0) {
                                 BUTTON_STATUS(EQUIP_SLOT_C_LEFT) = BTN_DISABLED;
                                 BUTTON_STATUS(EQUIP_SLOT_C_DOWN) = BTN_DISABLED;
                                 BUTTON_STATUS(EQUIP_SLOT_C_RIGHT) = BTN_DISABLED;
@@ -716,8 +715,8 @@ RECOMP_PATCH void Interface_UpdateButtonsPart1(PlayState* play) {
                     restoreHudVisibility = true;
                 }
 
-                // @recomp_use_export_var no_bow_epona_fix: If B item is a sword, don't disable the UI.
-                if (!no_bow_epona_fix) {
+                // @recomp_use_export_var no_bow_epona_fix: If riding Epona, don't disable the UI.
+                if (!no_bow_epona_fix || (player->stateFlags1 & PLAYER_STATE1_800000) == 0) {
                     BUTTON_STATUS(EQUIP_SLOT_C_LEFT) = BTN_DISABLED;
                     BUTTON_STATUS(EQUIP_SLOT_C_DOWN) = BTN_DISABLED;
                     BUTTON_STATUS(EQUIP_SLOT_C_RIGHT) = BTN_DISABLED;

--- a/patches/input.c
+++ b/patches/input.c
@@ -614,6 +614,7 @@ RECOMP_PATCH void Interface_UpdateButtonsPart1(PlayState* play) {
                             if (no_bow_epona_fix) {
                                 if (gSaveContext.save.saveInfo.inventory.items[SLOT_BOW] == ITEM_BOW) {
                                     BUTTON_ITEM_EQUIP(CUR_FORM, EQUIP_SLOT_B) = ITEM_BOW;
+                                    BUTTON_STATUS(EQUIP_SLOT_B) = BTN_ENABLED;
                                 }
                             } else {
                                 BUTTON_ITEM_EQUIP(CUR_FORM, EQUIP_SLOT_B) = ITEM_BOW;
@@ -633,8 +634,9 @@ RECOMP_PATCH void Interface_UpdateButtonsPart1(PlayState* play) {
                                 Interface_LoadItemIconImpl(play, EQUIP_SLOT_B);
                             }
 
-                            // @recomp_use_export_var no_bow_epona_fix: If riding Epona, don't disable the UI.
-                            if (!no_bow_epona_fix || (player->stateFlags1 & PLAYER_STATE1_800000) == 0) {
+                            // @recomp_use_export_var no_bow_epona_fix: If the B button does not contain a sword, don't disable the UI.
+                            if (!no_bow_epona_fix || BUTTON_ITEM_EQUIP(CUR_FORM, EQUIP_SLOT_B) < ITEM_SWORD_KOKIRI ||
+                                BUTTON_ITEM_EQUIP(CUR_FORM, EQUIP_SLOT_B) > ITEM_SWORD_GILDED) {
                                 BUTTON_STATUS(EQUIP_SLOT_C_LEFT) = BTN_DISABLED;
                                 BUTTON_STATUS(EQUIP_SLOT_C_DOWN) = BTN_DISABLED;
                                 BUTTON_STATUS(EQUIP_SLOT_C_RIGHT) = BTN_DISABLED;
@@ -642,6 +644,10 @@ RECOMP_PATCH void Interface_UpdateButtonsPart1(PlayState* play) {
                                 Interface_SetHudVisibility(HUD_VISIBILITY_A_HEARTS_MAGIC_MINIMAP_WITH_OVERWRITE);
                             }
                         }
+                    }
+
+                    if (BUTTON_STATUS(EQUIP_SLOT_B) == BTN_DISABLED && BUTTON_ITEM_EQUIP(CUR_FORM, EQUIP_SLOT_B) == ITEM_BOW) {
+                        BUTTON_STATUS(EQUIP_SLOT_B) = BTN_ENABLED;
                     }
 
                     if (play->transitionMode != TRANS_MODE_OFF) {
@@ -689,6 +695,7 @@ RECOMP_PATCH void Interface_UpdateButtonsPart1(PlayState* play) {
                     if (no_bow_epona_fix) {
                         if (gSaveContext.save.saveInfo.inventory.items[SLOT_BOW] == ITEM_BOW) {
                             BUTTON_ITEM_EQUIP(CUR_FORM, EQUIP_SLOT_B) = ITEM_BOW;
+                            BUTTON_STATUS(EQUIP_SLOT_B) = BTN_ENABLED;
                         }
                     } else {
                         BUTTON_ITEM_EQUIP(CUR_FORM, EQUIP_SLOT_B) = ITEM_BOW;
@@ -709,14 +716,20 @@ RECOMP_PATCH void Interface_UpdateButtonsPart1(PlayState* play) {
                     Interface_LoadItemIconImpl(play, EQUIP_SLOT_B);
                 }
 
-                // @recomp_use_export_var no_bow_epona_fix: Don't enable the B button or restore hud visibility from Epona without a sword.
-                if (BUTTON_STATUS(EQUIP_SLOT_B) == BTN_DISABLED && (!no_bow_epona_fix || (player->stateFlags1 & PLAYER_STATE1_800000) == 0)) {
-                    BUTTON_STATUS(EQUIP_SLOT_B) = BTN_ENABLED;
-                    restoreHudVisibility = true;
+                if (BUTTON_STATUS(EQUIP_SLOT_B) == BTN_DISABLED) {
+                    // @recomp_use_export_var no_bow_epona_fix: Don't enable the B button unless it is being used for the bow.
+                    if (!no_bow_epona_fix || BUTTON_ITEM_EQUIP(CUR_FORM, EQUIP_SLOT_B) == ITEM_BOW) {
+                        BUTTON_STATUS(EQUIP_SLOT_B) = BTN_ENABLED;
+                    }
+
+                    // @recomp_use_export_var no_bow_epona_fix: Don't restore hud visibility from Epona without a sword.
+                    if (!no_bow_epona_fix || (player->stateFlags1 & PLAYER_STATE1_800000) == 0) {
+                        restoreHudVisibility = true;
+                    }
                 }
 
-                // @recomp_use_export_var no_bow_epona_fix: If riding Epona, don't disable the UI.
-                if (!no_bow_epona_fix || (player->stateFlags1 & PLAYER_STATE1_800000) == 0) {
+                // @recomp_use_export_var no_bow_epona_fix: If the B button does not contain the bow, don't disable the UI.
+                if (!no_bow_epona_fix || BUTTON_ITEM_EQUIP(CUR_FORM, EQUIP_SLOT_B) == ITEM_BOW) {
                     BUTTON_STATUS(EQUIP_SLOT_C_LEFT) = BTN_DISABLED;
                     BUTTON_STATUS(EQUIP_SLOT_C_DOWN) = BTN_DISABLED;
                     BUTTON_STATUS(EQUIP_SLOT_C_RIGHT) = BTN_DISABLED;

--- a/patches/input.c
+++ b/patches/input.c
@@ -534,6 +534,13 @@ RECOMP_PATCH void Player_Action_86(Player *this, PlayState *play) {
     func_808550D0(play, this, this->unk_B10[4], this->unk_B10[5], (this->transformation == PLAYER_FORM_HUMAN) ? 0 : 1);
 }
 
+bool no_bow_epona_fix = false;
+
+// @recomp_export void recomp_set_no_bow_epona_fix(bool new_val): Set whether to enable the fix for getting on Epona without a bow.
+RECOMP_EXPORT void recomp_set_no_bow_epona_fix(bool new_val) {
+    no_bow_epona_fix = new_val;
+}
+
 extern s16 sPictoState;
 extern s16 sPictoPhotoBeingTaken;
 extern void* gWorkBuffer;
@@ -603,21 +610,38 @@ RECOMP_PATCH void Interface_UpdateButtonsPart1(PlayState* play) {
                             BUTTON_STATUS(EQUIP_SLOT_C_RIGHT) = BTN_DISABLED;
                             set_extra_item_slot_status(BTN_DISABLED);
                         } else {
-                            BUTTON_ITEM_EQUIP(CUR_FORM, EQUIP_SLOT_B) = ITEM_BOW;
+                            // @recomp_use_export_var no_bow_epona_fix: Part of the no bow Epona fix.
+                            if (no_bow_epona_fix) {
+                                if (gSaveContext.save.saveInfo.inventory.items[SLOT_BOW] == ITEM_BOW) {
+                                    BUTTON_ITEM_EQUIP(CUR_FORM, EQUIP_SLOT_B) = ITEM_BOW;
+                                }
+                            } else {
+                                BUTTON_ITEM_EQUIP(CUR_FORM, EQUIP_SLOT_B) = ITEM_BOW;
+                            }
 
                             if (play->unk_1887C >= 2) {
                                 Interface_LoadItemIconImpl(play, EQUIP_SLOT_B);
                             } else if (gSaveContext.save.saveInfo.inventory.items[SLOT_BOW] == ITEM_NONE) {
-                                BUTTON_ITEM_EQUIP(CUR_FORM, EQUIP_SLOT_B) = ITEM_NONE;
+                                // @recomp_use_export_var no_bow_epona_fix: Part of the no bow Epona fix.
+                                if (no_bow_epona_fix) {
+                                    gSaveContext.buttonStatus[EQUIP_SLOT_B] = BUTTON_ITEM_EQUIP(CUR_FORM, EQUIP_SLOT_B);
+                                    BUTTON_STATUS(EQUIP_SLOT_B) = BTN_DISABLED;
+                                } else {
+                                    BUTTON_ITEM_EQUIP(CUR_FORM, EQUIP_SLOT_B) = ITEM_NONE;
+                                }
                             } else {
                                 Interface_LoadItemIconImpl(play, EQUIP_SLOT_B);
                             }
 
-                            BUTTON_STATUS(EQUIP_SLOT_C_LEFT) = BTN_DISABLED;
-                            BUTTON_STATUS(EQUIP_SLOT_C_DOWN) = BTN_DISABLED;
-                            BUTTON_STATUS(EQUIP_SLOT_C_RIGHT) = BTN_DISABLED;
-                            set_extra_item_slot_status(BTN_DISABLED);
-                            Interface_SetHudVisibility(HUD_VISIBILITY_A_HEARTS_MAGIC_MINIMAP_WITH_OVERWRITE);
+                            // @recomp_use_export_var no_bow_epona_fix: If B item is a sword, don't disable the UI.
+                            if (!no_bow_epona_fix || (BUTTON_ITEM_EQUIP(CUR_FORM, EQUIP_SLOT_B) < ITEM_SWORD_KOKIRI ||
+                                BUTTON_ITEM_EQUIP(CUR_FORM, EQUIP_SLOT_B) > ITEM_SWORD_GILDED)) {
+                                BUTTON_STATUS(EQUIP_SLOT_C_LEFT) = BTN_DISABLED;
+                                BUTTON_STATUS(EQUIP_SLOT_C_DOWN) = BTN_DISABLED;
+                                BUTTON_STATUS(EQUIP_SLOT_C_RIGHT) = BTN_DISABLED;
+                                set_extra_item_slot_status(BTN_DISABLED);
+                                Interface_SetHudVisibility(HUD_VISIBILITY_A_HEARTS_MAGIC_MINIMAP_WITH_OVERWRITE);
+                            }
                         }
                     }
 
@@ -662,27 +686,44 @@ RECOMP_PATCH void Interface_UpdateButtonsPart1(PlayState* play) {
                     BUTTON_STATUS(EQUIP_SLOT_C_RIGHT) = BTN_DISABLED;
                     set_extra_item_slot_status(BTN_DISABLED);
                 } else {
-                    BUTTON_ITEM_EQUIP(CUR_FORM, EQUIP_SLOT_B) = ITEM_BOW;
+                    // @recomp_use_export_var no_bow_epona_fix: Part of the no bow Epona fix.
+                    if (no_bow_epona_fix) {
+                        if (gSaveContext.save.saveInfo.inventory.items[SLOT_BOW] == ITEM_BOW) {
+                            BUTTON_ITEM_EQUIP(CUR_FORM, EQUIP_SLOT_B) = ITEM_BOW;
+                        }
+                    } else {
+                        BUTTON_ITEM_EQUIP(CUR_FORM, EQUIP_SLOT_B) = ITEM_BOW;
+                    }
                 }
 
                 if (play->unk_1887C >= 2) {
                     Interface_LoadItemIconImpl(play, EQUIP_SLOT_B);
                 } else if (gSaveContext.save.saveInfo.inventory.items[SLOT_BOW] == ITEM_NONE) {
-                    BUTTON_ITEM_EQUIP(CUR_FORM, EQUIP_SLOT_B) = ITEM_NONE;
+                    // @recomp_use_export_var no_bow_epona_fix: Part of the no bow Epona fix.
+                    if (no_bow_epona_fix) {
+                        gSaveContext.buttonStatus[EQUIP_SLOT_B] = BUTTON_ITEM_EQUIP(CUR_FORM, EQUIP_SLOT_B);
+                        BUTTON_STATUS(EQUIP_SLOT_B) = BTN_DISABLED;
+                    } else {
+                        BUTTON_ITEM_EQUIP(CUR_FORM, EQUIP_SLOT_B) = ITEM_NONE;
+                    }
                 } else {
                     Interface_LoadItemIconImpl(play, EQUIP_SLOT_B);
                 }
 
-                if (BUTTON_STATUS(EQUIP_SLOT_B) == BTN_DISABLED) {
+                // @recomp_use_export_var no_bow_epona_fix: Don't enable the B button or restore hud visibility from Epona without a sword.
+                if ((player->stateFlags1 & PLAYER_STATE1_800000) == 0 || (!no_bow_epona_fix && BUTTON_STATUS(EQUIP_SLOT_B) == BTN_DISABLED)) {
                     BUTTON_STATUS(EQUIP_SLOT_B) = BTN_ENABLED;
                     restoreHudVisibility = true;
                 }
 
-                BUTTON_STATUS(EQUIP_SLOT_C_LEFT) = BTN_DISABLED;
-                BUTTON_STATUS(EQUIP_SLOT_C_DOWN) = BTN_DISABLED;
-                BUTTON_STATUS(EQUIP_SLOT_C_RIGHT) = BTN_DISABLED;
-                set_extra_item_slot_status(BTN_DISABLED);
-                Interface_SetHudVisibility(HUD_VISIBILITY_A_HEARTS_MAGIC_MINIMAP_WITH_OVERWRITE);
+                // @recomp_use_export_var no_bow_epona_fix: If B item is a sword, don't disable the UI.
+                if (!no_bow_epona_fix) {
+                    BUTTON_STATUS(EQUIP_SLOT_C_LEFT) = BTN_DISABLED;
+                    BUTTON_STATUS(EQUIP_SLOT_C_DOWN) = BTN_DISABLED;
+                    BUTTON_STATUS(EQUIP_SLOT_C_RIGHT) = BTN_DISABLED;
+                    set_extra_item_slot_status(BTN_DISABLED);
+                    Interface_SetHudVisibility(HUD_VISIBILITY_A_HEARTS_MAGIC_MINIMAP_WITH_OVERWRITE);
+                }
 
                 if (play->transitionMode != TRANS_MODE_OFF) {
                     Interface_SetHudVisibility(HUD_VISIBILITY_NONE);
@@ -800,6 +841,13 @@ RECOMP_PATCH void Interface_UpdateButtonsPart1(PlayState* play) {
             Interface_SetHudVisibility(HUD_VISIBILITY_ALL);
         }
     }
+}
+
+bool fd_anywhere = false;
+
+// @recomp_export void recomp_set_fd_anywhere(bool new_val): Set whether the Fierce Deity's Mask has scene restrictions.
+RECOMP_EXPORT void recomp_set_fd_anywhere(bool new_val) {
+    fd_anywhere = new_val;
 }
 
 /**
@@ -1181,7 +1229,8 @@ RECOMP_PATCH void Interface_UpdateButtonsPart2(PlayState* play) {
                     }
                 } else if (GET_CUR_FORM_BTN_ITEM(i) == ITEM_MASK_FIERCE_DEITY) {
                     // Fierce Deity's Mask is equipped
-                    if ((play->sceneId != SCENE_MITURIN_BS) && (play->sceneId != SCENE_HAKUGIN_BS) &&
+                    // @recomp_use_export_var fd_anywhere: Allow the player to use the Fierce Deity's Mask anywhere if mods enable it.
+                    if (!fd_anywhere && (play->sceneId != SCENE_MITURIN_BS) && (play->sceneId != SCENE_HAKUGIN_BS) &&
                         (play->sceneId != SCENE_SEA_BS) && (play->sceneId != SCENE_INISIE_BS) &&
                         (play->sceneId != SCENE_LAST_BS)) {
                         if (BUTTON_STATUS(i) != BTN_DISABLED) {

--- a/patches/input.c
+++ b/patches/input.c
@@ -711,7 +711,7 @@ RECOMP_PATCH void Interface_UpdateButtonsPart1(PlayState* play) {
                 }
 
                 // @recomp_use_export_var no_bow_epona_fix: Don't enable the B button or restore hud visibility from Epona without a sword.
-                if ((player->stateFlags1 & PLAYER_STATE1_800000) == 0 || (!no_bow_epona_fix && BUTTON_STATUS(EQUIP_SLOT_B) == BTN_DISABLED)) {
+                if (BUTTON_STATUS(EQUIP_SLOT_B) == BTN_DISABLED && (!no_bow_epona_fix || (player->stateFlags1 & PLAYER_STATE1_800000) == 0)) {
                     BUTTON_STATUS(EQUIP_SLOT_B) = BTN_ENABLED;
                     restoreHudVisibility = true;
                 }


### PR DESCRIPTION
Implement FD anywhere and Epona fixes right in base recomp as settable export variables. Unfortunately the function needed to implement both of these features is already patched by base, so these exports are necessary to avoid a force patch.

<!--- section:artifacts:start -->
### Build Artifacts
- [Zelda64Recompiled-Linux-ARM64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2049518250.zip)
- [Zelda64Recompiled-Linux-ARM64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2049518972.zip)
- [Zelda64Recompiled-AppImage-ARM64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2049519176.zip)
- [Zelda64Recompiled-AppImage-ARM64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2049520270.zip)
- [Zelda64Recompiled-Windows-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2049521727.zip)
- [Zelda64Recompiled-Windows-RelWithDebInfo.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2049521828.zip)
- [Zelda64Recompiled-PDB-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2049521833.zip)
- [Zelda64Recompiled-PDB-RelWithDebInfo.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2049521927.zip)
- [Zelda64Recompiled-AppImage-X64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2049522320.zip)
- [Zelda64Recompiled-AppImage-X64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2049522322.zip)
- [Zelda64Recompiled-Linux-X64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2049522323.zip)
- [Zelda64Recompiled-Linux-X64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2049522324.zip)
<!--- section:artifacts:end -->