### PR TITLE
epona fixes fixes

### DIFF
--- a/patches/input.c
+++ b/patches/input.c
@@ -546,6 +546,9 @@ extern s16 sPictoPhotoBeingTaken;
 extern void* gWorkBuffer;
 u16 func_801A5100(void);
 
+#define ON_EPONA (player->stateFlags1 & PLAYER_STATE1_800000)
+#define EPONA_FIX_ACTIVE (no_bow_epona_fix && ON_EPONA)
+
 // @recomp Patched to update status of extra buttons via set_extra_item_slot_status.
 RECOMP_PATCH void Interface_UpdateButtonsPart1(PlayState* play) {
     InterfaceContext* interfaceCtx = &play->interfaceCtx;
@@ -555,11 +558,11 @@ RECOMP_PATCH void Interface_UpdateButtonsPart1(PlayState* play) {
 
     if (gSaveContext.save.cutsceneIndex < 0xFFF0) {
         gSaveContext.hudVisibilityForceButtonAlphasByStatus = false;
-        if ((player->stateFlags1 & PLAYER_STATE1_800000) || CHECK_WEEKEVENTREG(WEEKEVENTREG_08_01) ||
+        if (ON_EPONA || CHECK_WEEKEVENTREG(WEEKEVENTREG_08_01) ||
             (!CHECK_EVENTINF(EVENTINF_41) && (play->unk_1887C >= 2))) {
             // Riding Epona OR Honey & Darling minigame OR Horseback balloon minigame OR related to swamp boat
             // (non-minigame?)
-            if ((player->stateFlags1 & PLAYER_STATE1_800000) && (player->currentMask == PLAYER_MASK_BLAST) &&
+            if (ON_EPONA && (player->currentMask == PLAYER_MASK_BLAST) &&
                 (gSaveContext.bButtonStatus == BTN_DISABLED)) {
                 // Riding Epona with blast mask?
                 restoreHudVisibility = true;
@@ -611,7 +614,7 @@ RECOMP_PATCH void Interface_UpdateButtonsPart1(PlayState* play) {
                             set_extra_item_slot_status(BTN_DISABLED);
                         } else {
                             // @recomp_use_export_var no_bow_epona_fix: Part of the no bow Epona fix.
-                            if (no_bow_epona_fix) {
+                            if (EPONA_FIX_ACTIVE) {
                                 if (gSaveContext.save.saveInfo.inventory.items[SLOT_BOW] == ITEM_BOW) {
                                     BUTTON_ITEM_EQUIP(CUR_FORM, EQUIP_SLOT_B) = ITEM_BOW;
                                     BUTTON_STATUS(EQUIP_SLOT_B) = BTN_ENABLED;
@@ -624,7 +627,7 @@ RECOMP_PATCH void Interface_UpdateButtonsPart1(PlayState* play) {
                                 Interface_LoadItemIconImpl(play, EQUIP_SLOT_B);
                             } else if (gSaveContext.save.saveInfo.inventory.items[SLOT_BOW] == ITEM_NONE) {
                                 // @recomp_use_export_var no_bow_epona_fix: Part of the no bow Epona fix.
-                                if (no_bow_epona_fix) {
+                                if (EPONA_FIX_ACTIVE) {
                                     gSaveContext.buttonStatus[EQUIP_SLOT_B] = BUTTON_ITEM_EQUIP(CUR_FORM, EQUIP_SLOT_B);
                                     BUTTON_STATUS(EQUIP_SLOT_B) = BTN_DISABLED;
                                 } else {
@@ -635,7 +638,7 @@ RECOMP_PATCH void Interface_UpdateButtonsPart1(PlayState* play) {
                             }
 
                             // @recomp_use_export_var no_bow_epona_fix: If the B button does not contain a sword, don't disable the UI.
-                            if (!no_bow_epona_fix || BUTTON_ITEM_EQUIP(CUR_FORM, EQUIP_SLOT_B) < ITEM_SWORD_KOKIRI ||
+                            if (!EPONA_FIX_ACTIVE || BUTTON_ITEM_EQUIP(CUR_FORM, EQUIP_SLOT_B) < ITEM_SWORD_KOKIRI ||
                                 BUTTON_ITEM_EQUIP(CUR_FORM, EQUIP_SLOT_B) > ITEM_SWORD_GILDED) {
                                 BUTTON_STATUS(EQUIP_SLOT_C_LEFT) = BTN_DISABLED;
                                 BUTTON_STATUS(EQUIP_SLOT_C_DOWN) = BTN_DISABLED;
@@ -669,12 +672,12 @@ RECOMP_PATCH void Interface_UpdateButtonsPart1(PlayState* play) {
                         BUTTON_STATUS(EQUIP_SLOT_C_RIGHT) = BTN_DISABLED;
                         set_extra_item_slot_status(BTN_DISABLED);
                         Interface_SetHudVisibility(HUD_VISIBILITY_A_B_MINIMAP);
-                    } else if (player->stateFlags1 & PLAYER_STATE1_800000) {
+                    } else if (ON_EPONA) {
                         Interface_SetHudVisibility(HUD_VISIBILITY_A_B_MINIMAP);
                     }
                 }
             } else {
-                if (player->stateFlags1 & PLAYER_STATE1_800000) {
+                if (ON_EPONA) {
                     Interface_SetHudVisibility(HUD_VISIBILITY_A_B_MINIMAP);
                 }
 
@@ -692,7 +695,7 @@ RECOMP_PATCH void Interface_UpdateButtonsPart1(PlayState* play) {
                     set_extra_item_slot_status(BTN_DISABLED);
                 } else {
                     // @recomp_use_export_var no_bow_epona_fix: Part of the no bow Epona fix.
-                    if (no_bow_epona_fix) {
+                    if (EPONA_FIX_ACTIVE) {
                         if (gSaveContext.save.saveInfo.inventory.items[SLOT_BOW] == ITEM_BOW) {
                             BUTTON_ITEM_EQUIP(CUR_FORM, EQUIP_SLOT_B) = ITEM_BOW;
                             BUTTON_STATUS(EQUIP_SLOT_B) = BTN_ENABLED;
@@ -706,7 +709,7 @@ RECOMP_PATCH void Interface_UpdateButtonsPart1(PlayState* play) {
                     Interface_LoadItemIconImpl(play, EQUIP_SLOT_B);
                 } else if (gSaveContext.save.saveInfo.inventory.items[SLOT_BOW] == ITEM_NONE) {
                     // @recomp_use_export_var no_bow_epona_fix: Part of the no bow Epona fix.
-                    if (no_bow_epona_fix) {
+                    if (EPONA_FIX_ACTIVE) {
                         gSaveContext.buttonStatus[EQUIP_SLOT_B] = BUTTON_ITEM_EQUIP(CUR_FORM, EQUIP_SLOT_B);
                         BUTTON_STATUS(EQUIP_SLOT_B) = BTN_DISABLED;
                     } else {
@@ -753,7 +756,7 @@ RECOMP_PATCH void Interface_UpdateButtonsPart1(PlayState* play) {
                     BUTTON_STATUS(EQUIP_SLOT_C_RIGHT) = BTN_DISABLED;
                     set_extra_item_slot_status(BTN_DISABLED);
                     Interface_SetHudVisibility(HUD_VISIBILITY_A_B_MINIMAP);
-                } else if (player->stateFlags1 & PLAYER_STATE1_800000) {
+                } else if (ON_EPONA) {
                     Interface_SetHudVisibility(HUD_VISIBILITY_A_B_MINIMAP);
                 }
             }


### PR DESCRIPTION
this group of epona fixes fixes fixes epona fixes

...We found a bug. 🥴 Epona fixes trigger placing the Ocarina on the player's B button upon clearing a minigame that changes it, for us it was Town Shooting Gallery. The bug is non-existent if Epona fixes are disabled of course, but these changes fix it.

<!--- section:artifacts:start -->
### Build Artifacts
- [Zelda64Recompiled-Linux-ARM64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2076232906.zip)
- [Zelda64Recompiled-Linux-ARM64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2076232945.zip)
- [Zelda64Recompiled-AppImage-ARM64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2076234796.zip)
- [Zelda64Recompiled-AppImage-ARM64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2076234973.zip)
- [Zelda64Recompiled-Windows-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2076237252.zip)
- [Zelda64Recompiled-PDB-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2076237433.zip)
- [Zelda64Recompiled-Windows-RelWithDebInfo.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2076238071.zip)
- [Zelda64Recompiled-PDB-RelWithDebInfo.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2076238277.zip)
- [Zelda64Recompiled-AppImage-X64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2076240937.zip)
- [Zelda64Recompiled-AppImage-X64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2076240939.zip)
- [Zelda64Recompiled-Linux-X64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2076240940.zip)
- [Zelda64Recompiled-Linux-X64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2076240942.zip)
<!--- section:artifacts:end -->