### PR TITLE
Added Recomp Events for before and after first-person aiming update.

### DIFF
--- a/patches/input.c
+++ b/patches/input.c
@@ -14,7 +14,7 @@ s16 func_80832754(Player* this, s32 arg1);
 s32 func_8082EF20(Player* this);
 
 // This flag is reset every frame by 'poll_inputs()'.
-RecompAimingOverideMode recomp_aiming_override_mode = RECOMP_AIMINIG_OVERRIDE_OFF;
+RecompAimingOverideMode recomp_aiming_override_mode = RECOMP_AIMING_OVERRIDE_OFF;
 
 // @recomp Patched to add gyro and mouse aiming.
 RECOMP_PATCH s32 func_80847190(PlayState* play, Player* this, s32 arg2) {
@@ -34,7 +34,7 @@ RECOMP_PATCH s32 func_80847190(PlayState* play, Player* this, s32 arg2) {
     // @recomp Get the analog camera input values if analog cam is enabled, or right-stick aiming is being forced.
     s32 analog_x = 0;
     s32 analog_y = 0;
-    if (recomp_analog_cam_enabled() || recomp_aiming_override_mode == RECOMP_AIMINIG_OVERRIDE_FORCE_RIGHT_STICK) {
+    if (recomp_analog_cam_enabled() || recomp_aiming_override_mode == RECOMP_AIMING_OVERRIDE_FORCE_RIGHT_STICK) {
         float analog_x_float = 0.0f;
         float analog_y_float = 0.0f;
         recomp_get_camera_inputs(&analog_x_float, &analog_y_float);
@@ -51,12 +51,11 @@ RECOMP_PATCH s32 func_80847190(PlayState* play, Player* this, s32 arg2) {
 
     if (in_free_look) {
         // @recomp Add in the analog camera Y input. Clamp to prevent moving the camera twice as fast if both sticks are held.
-        if (recomp_aiming_override_mode != RECOMP_AIMINIG_OVERRIDE_OFF) {
-            var_s0 = CLAMP(analog_y, -61, 61) * 0xF0;
+        s32 cam_input_y = analog_y;
+        if (recomp_aiming_override_mode == RECOMP_AIMING_OVERRIDE_OFF) {
+            cam_input_y += play->state.input[0].rel.stick_y;
         }
-        else {
-            var_s0 = CLAMP(play->state.input[0].rel.stick_y + analog_y, -61, 61) * 0xF0;
-        }
+        var_s0 = CLAMP(cam_input_y, -61, 61) * 0xF0;
         
         // @recomp Invert the Y axis accordingly (default is inverted, so negate if not inverted).
         if (!inverted_y) {
@@ -65,12 +64,11 @@ RECOMP_PATCH s32 func_80847190(PlayState* play, Player* this, s32 arg2) {
         Math_SmoothStepToS(&this->actor.focus.rot.x, var_s0, 0xE, 0xFA0, 0x1E);
 
         // @recomp Add in the analog camera X input. Clamp to prevent moving the camera twice as fast if both sticks are held.
-        if (recomp_aiming_override_mode != RECOMP_AIMINIG_OVERRIDE_OFF) {
-            var_s0 = CLAMP(analog_x, -61, 61) * -0x10;
+        s32 cam_input_x = analog_x;
+        if (recomp_aiming_override_mode == RECOMP_AIMING_OVERRIDE_OFF) {
+            cam_input_x += play->state.input[0].rel.stick_x;
         }
-        else {
-            var_s0 = CLAMP(play->state.input[0].rel.stick_x + analog_x, -61, 61) * -0x10;
-        }
+        var_s0 = CLAMP(cam_input_x, -61, 61) * -0x10;
 
         // @recomp Invert the X axis accordingly
         if (inverted_x) {
@@ -121,13 +119,12 @@ RECOMP_PATCH s32 func_80847190(PlayState* play, Player* this, s32 arg2) {
 
         // @recomp Invert the Y axis accordingly (default is inverted, so negate if not inverted).
         // Also add in the analog camera Y input. Clamp to prevent moving the camera twice as fast if both sticks are held.
+        s32 cam_input_y = analog_y;
+        if (recomp_aiming_override_mode == RECOMP_AIMING_OVERRIDE_OFF) {
+            cam_input_y += play->state.input[0].rel.stick_y;
+        }
         s32 stick_y;
-        if (recomp_aiming_override_mode != RECOMP_AIMINIG_OVERRIDE_OFF) {
-            stick_y = CLAMP(analog_y, -61, 61);
-        }
-        else {
-            stick_y = CLAMP(play->state.input[0].rel.stick_y + analog_y, -61, 61);
-        }
+        stick_y = CLAMP(cam_input_y, -61, 61);
 
         if (!inverted_y) {
             stick_y = -stick_y;
@@ -149,13 +146,12 @@ RECOMP_PATCH s32 func_80847190(PlayState* play, Player* this, s32 arg2) {
 
         // @recomp Invert the X axis accordingly. Also add in the analog camera Y input.
         // Clamp to prevent moving the camera twice as fast if both sticks are held.
+        s32 cam_input_x = analog_x;
+        if (recomp_aiming_override_mode == RECOMP_AIMING_OVERRIDE_OFF) {
+            cam_input_x += play->state.input[0].rel.stick_x;
+        }
         s32 stick_x;
-        if (recomp_aiming_override_mode != RECOMP_AIMINIG_OVERRIDE_OFF) {
-            stick_x = CLAMP(analog_x, -61, 61);
-        }
-        else {
-            stick_x = CLAMP(play->state.input[0].rel.stick_x + analog_x, -61, 61);
-        }
+        stick_x = CLAMP(cam_input_x, -61, 61);
 
         if (inverted_x) {
             stick_x = -stick_x;

--- a/patches/input.h
+++ b/patches/input.h
@@ -9,9 +9,9 @@ typedef enum {
 } RecompCameraMode;
 
 typedef enum {
-    RECOMP_AIMINIG_OVERRIDE_OFF = 0,
-    RECOMP_AIMINIG_OVERRIDE_DISABLE_LEFT_STICK = 1,
-    RECOMP_AIMINIG_OVERRIDE_FORCE_RIGHT_STICK = 2
+    RECOMP_AIMING_OVERRIDE_OFF = 0,
+    RECOMP_AIMING_OVERRIDE_DISABLE_LEFT_STICK = 1,
+    RECOMP_AIMING_OVERRIDE_FORCE_RIGHT_STICK = 2
 } RecompAimingOverideMode;
 
 extern RecompCameraMode recomp_camera_mode;

--- a/patches/input.h
+++ b/patches/input.h
@@ -8,7 +8,14 @@ typedef enum {
     RECOMP_CAMERA_DUALANALOG,
 } RecompCameraMode;
 
+typedef enum {
+    RECOMP_AIMINIG_OVERRIDE_OFF = 0,
+    RECOMP_AIMINIG_OVERRIDE_DISABLE_LEFT_STICK = 1,
+    RECOMP_AIMINIG_OVERRIDE_FORCE_RIGHT_STICK = 2
+} RecompAimingOverideMode;
+
 extern RecompCameraMode recomp_camera_mode;
+extern RecompAimingOverideMode recomp_aiming_override_mode;
 
 DECLARE_FUNC(void, recomp_get_gyro_deltas, float* x, float* y);
 DECLARE_FUNC(void, recomp_get_mouse_deltas, float* x, float* y);

--- a/patches/input_latency.c
+++ b/patches/input_latency.c
@@ -70,17 +70,11 @@ void poll_inputs(void) {
     // Begin reading controller data
     osContStartReadData(serialEventQueue);
 
-
+    bool needs_right_stick = recomp_analog_cam_enabled() || recomp_aiming_override_mode == RECOMP_AIMING_OVERRIDE_FORCE_RIGHT_STICK;
     // Suppress the right analog stick if analog camera is active unless the ocarina is in use.
-    recomp_set_right_analog_suppressed(
-        (
-                recomp_analog_cam_enabled() 
-                || recomp_aiming_override_mode == RECOMP_AIMINIG_OVERRIDE_FORCE_RIGHT_STICK
-            )
-        && sOcarinaInstrumentId == OCARINA_INSTRUMENT_OFF
-    );
+    recomp_set_right_analog_suppressed(needs_right_stick && sOcarinaInstrumentId == OCARINA_INSTRUMENT_OFF);
     // Resets this flag for the next frame;
-    recomp_aiming_override_mode == RECOMP_AIMINIG_OVERRIDE_OFF;
+    recomp_aiming_override_mode = RECOMP_AIMING_OVERRIDE_OFF;
 
     // Wait for controller data
     osRecvMesg(serialEventQueue, NULL, OS_MESG_BLOCK);

--- a/patches/input_latency.c
+++ b/patches/input_latency.c
@@ -70,8 +70,17 @@ void poll_inputs(void) {
     // Begin reading controller data
     osContStartReadData(serialEventQueue);
 
+
     // Suppress the right analog stick if analog camera is active unless the ocarina is in use.
-    recomp_set_right_analog_suppressed(recomp_analog_cam_enabled() && sOcarinaInstrumentId == OCARINA_INSTRUMENT_OFF);
+    recomp_set_right_analog_suppressed(
+        (
+                recomp_analog_cam_enabled() 
+                || recomp_aiming_override_mode == RECOMP_AIMINIG_OVERRIDE_FORCE_RIGHT_STICK
+            )
+        && sOcarinaInstrumentId == OCARINA_INSTRUMENT_OFF
+    );
+    // Resets this flag for the next frame;
+    recomp_aiming_override_mode == RECOMP_AIMINIG_OVERRIDE_OFF;
 
     // Wait for controller data
     osRecvMesg(serialEventQueue, NULL, OS_MESG_BLOCK);


### PR DESCRIPTION
Everything needed in the mod API to implement movement in first person as it was in my original pull request.

Mods can also force right stick aiming.

<!--- section:artifacts:start -->
### Build Artifacts
- [Zelda64Recompiled-Linux-ARM64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2228319642.zip)
- [Zelda64Recompiled-Windows-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2228319705.zip)
- [Zelda64Recompiled-PDB-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2228319758.zip)
- [Zelda64Recompiled-AppImage-ARM64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2228320270.zip)
- [Zelda64Recompiled-Windows-RelWithDebInfo.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2228320654.zip)
- [Zelda64Recompiled-PDB-RelWithDebInfo.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2228320712.zip)
- [Zelda64Recompiled-Linux-ARM64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2228320994.zip)
- [Zelda64Recompiled-AppImage-ARM64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2228321669.zip)
- [Zelda64Recompiled-AppImage-X64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2228321846.zip)
- [Zelda64Recompiled-AppImage-X64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2228321849.zip)
- [Zelda64Recompiled-Linux-X64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2228321851.zip)
- [Zelda64Recompiled-Linux-X64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2228321852.zip)
<!--- section:artifacts:end -->