### PR TITLE
Fix "fixup_bundle: not a valid bundle" issue on xcode builds.

### DIFF
--- a/.github/macos/fixup_bundle.cmake
+++ b/.github/macos/fixup_bundle.cmake
@@ -1,8 +1,14 @@
 include(BundleUtilities)
 
+# Xcode generator puts the build type in the build directory
+set(BUILD_PREFIX "")
+if (CMAKE_GENERATOR STREQUAL "Xcode")
+    set(BUILD_PREFIX "${CMAKE_BUILD_TYPE}/")
+endif()
+
 # Use generator expressions to get the absolute path to the bundle and frameworks
-set(APPS "Zelda64Recompiled.app/Contents/MacOS/Zelda64Recompiled")
-set(DIRS "Zelda64Recompiled.app/Contents/Frameworks")
+set(APPS "${BUILD_PREFIX}Zelda64Recompiled.app/Contents/MacOS/Zelda64Recompiled")
+set(DIRS "${BUILD_PREFIX}Zelda64Recompiled.app/Contents/Frameworks")
 
 # The fixup_bundle command needs an absolute path
 file(REAL_PATH ${APPS} APPS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -355,7 +355,7 @@ if (APPLE)
     # Post-build steps for macOS bundle
     add_custom_command(TARGET Zelda64Recompiled POST_BUILD
         # Copy and fix frameworks first
-        COMMAND ${CMAKE_COMMAND} -P ${CMAKE_SOURCE_DIR}/.github/macos/fixup_bundle.cmake
+        COMMAND ${CMAKE_COMMAND} -D CMAKE_BUILD_TYPE=$<CONFIG> -D CMAKE_GENERATOR=${CMAKE_GENERATOR} -P ${CMAKE_SOURCE_DIR}/.github/macos/fixup_bundle.cmake
 
         # Copy all resources
         COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/assets ${CMAKE_BINARY_DIR}/temp_assets


### PR DESCRIPTION
 Xcode app directory was incorrect, it uses the build type as a prefix.