### PR TITLE
Fix portable mode on macOS.

### DIFF
--- a/include/zelda_support.h
+++ b/include/zelda_support.h
@@ -12,7 +12,8 @@ namespace zelda64 {
 // Apple specific methods that usually require Objective-C. Implemented in support_apple.mm.
 #ifdef __APPLE__
     void dispatch_on_ui_thread(std::function<void()> func);
-    const char* get_bundle_resource_directory();
+    std::filesystem::path get_bundle_resource_directory();
+    std::filesystem::path get_bundle_directory();
 #endif
 }
 

--- a/src/game/config.cpp
+++ b/src/game/config.cpp
@@ -2,6 +2,7 @@
 #include "recomp_input.h"
 #include "zelda_sound.h"
 #include "zelda_render.h"
+#include "zelda_support.h"
 #include "ultramodern/config.hpp"
 #include "librecomp/files.hpp"
 #include <filesystem>
@@ -135,6 +136,14 @@ std::filesystem::path zelda64::get_app_folder_path() {
    if (std::filesystem::exists("portable.txt")) {
        return std::filesystem::current_path();
    }
+
+#if defined(__APPLE__)
+   // Check for portable file in the directory containing the app bundle.
+   const auto app_bundle_path = zelda64::get_bundle_directory().parent_path();
+   if (std::filesystem::exists(app_bundle_path / "portable.txt")) {
+       return app_bundle_path;
+   }
+#endif
 
    std::filesystem::path recomp_dir{};
 

--- a/src/main/support.cpp
+++ b/src/main/support.cpp
@@ -25,9 +25,7 @@ namespace zelda64 {
     std::filesystem::path get_asset_path(const char* asset) {
         std::filesystem::path base_path = "";
 #if defined(__APPLE__)
-        const char* resource_dir = get_bundle_resource_directory();
-        base_path = resource_dir;
-        free((void*)resource_dir);
+        base_path = get_bundle_resource_directory();
 #endif
 
         return base_path / "assets" / asset;

--- a/src/main/support_apple.mm
+++ b/src/main/support_apple.mm
@@ -1,5 +1,4 @@
 #include "zelda_support.h"
-#include <dlfcn.h>
 #import <Foundation/Foundation.h>
 #import <objc/runtime.h>
 #import <objc/message.h>
@@ -19,35 +18,8 @@ namespace zelda64 {
     }
 
     std::filesystem::path get_bundle_directory() {
-        NSURL *bundleUrl = [[NSBundle mainBundle] bundleURL];
-
-        // The OS may relocate the app elsewhere for security reasons if, for example,
-        // it was downloaded and opened from the Downloads folder. In this case, we need
-        // to untranslocate the path to find out where the actual app bundle is.
-        if (void* securityHandle = dlopen("/System/Library/Frameworks/Security.framework/Security", RTLD_LAZY)) {
-            using IsTranslocatedURLFunc = Boolean (*)(CFURLRef path, bool* isTranslocated,
-                                                      CFErrorRef* __nullable error);
-            using CreateOriginalPathForURLFunc = CFURLRef __nullable (*)(CFURLRef translocatedPath,
-                                                                         CFErrorRef* __nullable error);
-
-            const auto IsTranslocatedURL = reinterpret_cast<IsTranslocatedURLFunc>(
-                dlsym(securityHandle, "SecTranslocateIsTranslocatedURL"));
-            const auto CreateOriginalPathForURL = reinterpret_cast<CreateOriginalPathForURLFunc>(
-                dlsym(securityHandle, "SecTranslocateCreateOriginalPathForURL"));
-
-            bool translocated = false;
-            if (IsTranslocatedURL && CreateOriginalPathForURL &&
-                IsTranslocatedURL((__bridge CFURLRef) bundleUrl, &translocated, nullptr) && translocated) {
-                CFURLRef untranslocated = CreateOriginalPathForURL((__bridge CFURLRef) bundleUrl, nullptr);
-                if (untranslocated) {
-                    bundleUrl = (NSURL*) untranslocated;
-                }
-            }
-
-            dlclose(securityHandle);
-        }
-
-        return std::filesystem::path([bundleUrl fileSystemRepresentation]);
+        NSString *bundlePath = [[NSBundle mainBundle] bundlePath];
+        return std::filesystem::path([bundlePath UTF8String]);
     }
 }
 

--- a/src/main/support_apple.mm
+++ b/src/main/support_apple.mm
@@ -1,4 +1,5 @@
 #include "zelda_support.h"
+#include <dlfcn.h>
 #import <Foundation/Foundation.h>
 #import <objc/runtime.h>
 #import <objc/message.h>
@@ -12,9 +13,41 @@ namespace zelda64 {
         });
     }
 
-    const char* get_bundle_resource_directory() {
+    std::filesystem::path get_bundle_resource_directory() {
         NSString *bundlePath = [[NSBundle mainBundle] resourcePath];
-        return strdup([bundlePath UTF8String]);
+        return std::filesystem::path([bundlePath UTF8String]);
+    }
+
+    std::filesystem::path get_bundle_directory() {
+        NSURL *bundleUrl = [[NSBundle mainBundle] bundleURL];
+
+        // The OS may relocate the app elsewhere for security reasons if, for example,
+        // it was downloaded and opened from the Downloads folder. In this case, we need
+        // to untranslocate the path to find out where the actual app bundle is.
+        if (void* securityHandle = dlopen("/System/Library/Frameworks/Security.framework/Security", RTLD_LAZY)) {
+            using IsTranslocatedURLFunc = Boolean (*)(CFURLRef path, bool* isTranslocated,
+                                                      CFErrorRef* __nullable error);
+            using CreateOriginalPathForURLFunc = CFURLRef __nullable (*)(CFURLRef translocatedPath,
+                                                                         CFErrorRef* __nullable error);
+
+            const auto IsTranslocatedURL = reinterpret_cast<IsTranslocatedURLFunc>(
+                dlsym(securityHandle, "SecTranslocateIsTranslocatedURL"));
+            const auto CreateOriginalPathForURL = reinterpret_cast<CreateOriginalPathForURLFunc>(
+                dlsym(securityHandle, "SecTranslocateCreateOriginalPathForURL"));
+
+            bool translocated = false;
+            if (IsTranslocatedURL && CreateOriginalPathForURL &&
+                IsTranslocatedURL((__bridge CFURLRef) bundleUrl, &translocated, nullptr) && translocated) {
+                CFURLRef untranslocated = CreateOriginalPathForURL((__bridge CFURLRef) bundleUrl, nullptr);
+                if (untranslocated) {
+                    bundleUrl = (NSURL*) untranslocated;
+                }
+            }
+
+            dlclose(securityHandle);
+        }
+
+        return std::filesystem::path([bundleUrl fileSystemRepresentation]);
     }
 }
 


### PR DESCRIPTION
On macOS, the app should look for `portable.txt` next to the app bundle, as:
* The executable is inside the app bundle, but user files should be outside next to the bundle itself.
* When opened from Finder, the working directory is not set next to the app bundle.

Tested this on my system; without `portable.txt`, the app bundle uses a user config directory as normal, and with `portable.txt` next to the bundle, it places the configuration files there as expected.

<!--- section:artifacts:start -->
### Build Artifacts
- [Zelda64Recompiled-Linux-X64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2803827340.zip)
- [Zelda64Recompiled-Linux-ARM64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2803827767.zip)
- [Zelda64Recompiled-AppImage-X64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2803827781.zip)
- [Zelda64Recompiled-AppImage-ARM64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2803828777.zip)
- [Zelda64Recompiled-Linux-X64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2803829445.zip)
- [Zelda64Recompiled-AppImage-X64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2803829832.zip)
- [Zelda64Recompiled-Linux-ARM64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2803829953.zip)
- [Zelda64Recompiled-AppImage-ARM64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2803830870.zip)
- [Zelda64Recompiled-macOS-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2803833334.zip)
- [Zelda64Recompiled-Windows-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2803834572.zip)
- [Zelda64Recompiled-PDB-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2803834680.zip)
- [Zelda64Recompiled-Windows-RelWithDebInfo.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2803836812.zip)
- [Zelda64Recompiled-PDB-RelWithDebInfo.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2803836927.zip)
- [Zelda64Recompiled-macOS-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2803849184.zip)
<!--- section:artifacts:end -->