### PR TITLE
Use Application Support directory on macOS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ You'll probably also want to change the default behavior so that you don't need 
 #### Where is the savefile stored?
 - Windows: `%LOCALAPPDATA%\Zelda64Recompiled\saves`
 - Linux: `~/.config/Zelda64Recompiled/saves`
+- macOS: `~/Library/Application Support/Zelda64Recompiled/saves`
 
 #### How do I choose a different ROM?
 **You don't.** This project is **only** a port of Majora's Mask (and Ocarina of Time in the future), and it will only accept one specific ROM: the US version of the N64 release of Majora's Mask. ROMs in formats other than .z64 will be automatically converted, as long as it is the correct ROM. **It is not an emulator and it cannot run any arbitrary ROM.** 

--- a/include/zelda_support.h
+++ b/include/zelda_support.h
@@ -3,6 +3,7 @@
 
 #include <functional>
 #include <filesystem>
+#include <optional>
 
 namespace zelda64 {
     std::filesystem::path get_asset_path(const char* asset);
@@ -12,6 +13,7 @@ namespace zelda64 {
 // Apple specific methods that usually require Objective-C. Implemented in support_apple.mm.
 #ifdef __APPLE__
     void dispatch_on_ui_thread(std::function<void()> func);
+    std::optional<std::filesystem::path> get_application_support_directory();
     std::filesystem::path get_bundle_resource_directory();
     std::filesystem::path get_bundle_directory();
 #endif

--- a/src/game/config.cpp
+++ b/src/game/config.cpp
@@ -162,6 +162,13 @@ std::filesystem::path zelda64::get_app_folder_path() {
        return std::filesystem::path{getenv("APP_FOLDER_PATH")};
    }
 
+#if defined(__APPLE__)
+   const auto supportdir = zelda64::get_application_support_directory();
+   if (supportdir) {
+       return *supportdir / zelda64::program_id;
+   }
+#endif
+
    const char *homedir;
 
    if ((homedir = getenv("HOME")) == nullptr) {

--- a/src/main/support_apple.mm
+++ b/src/main/support_apple.mm
@@ -12,6 +12,15 @@ namespace zelda64 {
         });
     }
 
+    std::optional<std::filesystem::path> get_application_support_directory() {
+        NSArray *dirs = NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES);
+        if ([dirs count] > 0) {
+            NSString *dir = [dirs firstObject];
+            return std::filesystem::path([dir UTF8String]);
+        }
+        return std::nullopt;
+    }
+
     std::filesystem::path get_bundle_resource_directory() {
         NSString *bundlePath = [[NSBundle mainBundle] resourcePath];
         return std::filesystem::path([bundlePath UTF8String]);


### PR DESCRIPTION
Changes the app path resolution logic to use the `~/Library/Application Support` directory on macOS instead of `~/.config`, as is standard for macOS apps.

Figured now would be a good time to propose this to avoid migrations, since there's still no official macOS release yet.

<!--- section:artifacts:start -->
### Build Artifacts
- [Zelda64Recompiled-Linux-ARM64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2803921367.zip)
- [Zelda64Recompiled-Linux-X64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2803922128.zip)
- [Zelda64Recompiled-AppImage-ARM64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2803922308.zip)
- [Zelda64Recompiled-AppImage-X64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2803922545.zip)
- [Zelda64Recompiled-Linux-ARM64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2803922675.zip)
- [Zelda64Recompiled-Linux-X64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2803922705.zip)
- [Zelda64Recompiled-AppImage-X64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2803923044.zip)
- [Zelda64Recompiled-AppImage-ARM64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2803923621.zip)
- [Zelda64Recompiled-Windows-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2803924909.zip)
- [Zelda64Recompiled-PDB-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2803924989.zip)
- [Zelda64Recompiled-macOS-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2803925000.zip)
- [Zelda64Recompiled-macOS-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2803925773.zip)
- [Zelda64Recompiled-Windows-RelWithDebInfo.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2803925997.zip)
- [Zelda64Recompiled-PDB-RelWithDebInfo.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/2803926080.zip)
<!--- section:artifacts:end -->