### PR TITLE
QOL: automatically enable native wayland if supported display is found

### DIFF
--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -67,6 +67,10 @@ ultramodern::gfx_callbacks_t::gfx_data_t create_gfx() {
     SDL_SetHint(SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH, "1");
     SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
 
+    if (getenv("WAYLAND_DISPLAY") != NULL) {
+        SDL_SetHint(SDL_HINT_VIDEODRIVER, "wayland");
+    }
+
     if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMECONTROLLER) > 0) {
         exit_error("Failed to initialize SDL2: %s\n", SDL_GetError());
     }


### PR DESCRIPTION
Just a simple quality of life trick to prevent users from having to tweak their environment to get this app to run natively on Wayland. (notably allowing for lossless scaling on HiDPI displays). This inclusion is obviously an opinionated decision, and I would totally understand it if you decide to reject this request.

Tested and working correctly on xfce (X11) and sway-fx (Wayland) so far. Can't do MacOS due to lack of hardware. Could try Windows 11 but getting a programing environment on there looks like pain.