### PR TITLE
Fixed interpolation glitch with Gibdo mask in Pamela cutscene

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,8 +309,6 @@ endif()
 
 if (CMAKE_SYSTEM_NAME MATCHES "Linux")
     find_package(SDL2 REQUIRED)
-    find_package(X11 REQUIRED)
-
     add_compile_definitions("RT64_SDL_WINDOW_VULKAN")
 
     # Generate icon_bytes.c from the app icon PNG.
@@ -324,14 +322,6 @@ if (CMAKE_SYSTEM_NAME MATCHES "Linux")
     message(STATUS "SDL2_INCLUDE_DIRS = ${SDL2_INCLUDE_DIRS}")
 
     target_include_directories(Zelda64Recompiled PRIVATE ${SDL2_INCLUDE_DIRS})
-
-    message(STATUS "X11_FOUND = ${X11_FOUND}")
-    message(STATUS "X11_Xrandr_FOUND = ${X11_Xrandr_FOUND}")
-    message(STATUS "X11_INCLUDE_DIR = ${X11_INCLUDE_DIR}")
-    message(STATUS "X11_LIBRARIES = ${X11_LIBRARIES}")
-
-    target_include_directories(Zelda64Recompiled PRIVATE ${X11_INCLUDE_DIR} ${X11_Xrandr_INCLUDE_PATH})
-    target_link_libraries(Zelda64Recompiled PRIVATE ${X11_LIBRARIES} ${X11_Xrandr_LIB})
 
     find_package(Freetype REQUIRED)
 

--- a/patches/autosaving.c
+++ b/patches/autosaving.c
@@ -70,7 +70,12 @@ void Sram_SyncWriteToFlash(SramContext* sramCtx, s32 curPage, s32 numPages);
 void recomp_reset_autosave_timer();
 void recomp_reset_autosave_timer_slow();
 
+RECOMP_DECLARE_EVENT(recomp_on_autosave(PlayState* play));
+RECOMP_DECLARE_EVENT(recomp_after_autosave(PlayState* play));
+
 RECOMP_EXPORT void recomp_do_autosave(PlayState* play) {
+    // @recomp_event recomp_on_autosave(PlayState* play): Autosave triggered.
+    recomp_on_autosave(play);
     // Transfer the scene flags into the cycle flags.
     Play_SaveCycleSceneFlags(&play->state);
     // Transfer the cycle flags into the save buffer. Logic copied from func_8014546C.
@@ -97,6 +102,9 @@ RECOMP_EXPORT void recomp_do_autosave(PlayState* play) {
     Sram_SyncWriteToFlash(sramCtx, gFlashOwlSaveStartPages[fileNum * 2 + 1], gFlashOwlSaveNumPages[fileNum * 2 + 1]);
 
     gSaveContext.save.isOwlSave = false;
+    
+    // @recomp_event recomp_on_autosave(PlayState* play): Autosave finished.
+    recomp_after_autosave(play);
 }
 
 bool loading_deletes_owl_save = true;

--- a/patches/specific_actor_transform_tagging.c
+++ b/patches/specific_actor_transform_tagging.c
@@ -12,6 +12,7 @@
 #include "overlays/actors/ovl_En_Twig/z_en_twig.h"
 #include "overlays/actors/ovl_En_Honotrap/z_en_honotrap.h"
 #include "overlays/actors/ovl_En_Tanron1/z_en_tanron1.h"
+#include "overlays/actors/ovl_Dm_Char05/z_dm_char05.h"
 
 // Decomp renames, TODO update decomp and remove these
 #define EnHonotrap_FlameGroup func_8092F878
@@ -1330,4 +1331,27 @@ RECOMP_PATCH void func_80BB5AAC(EnTanron1* this, PlayState* play) {
     }
 
     CLOSE_DISPS(play->state.gfxCtx);
+}
+
+extern void func_80AADF54(PlayState* play, DmChar05* this);
+
+// @recomp Patched to avoid an interpolation glitch in Pamela's dad's cutscene
+// that happens when the mask is meant to teleport offscreen.
+RECOMP_PATCH void func_80AADB4C(Actor* thisx, PlayState* play) {
+    DmChar05* this = (DmChar05*)thisx;
+    if (this->unk_18E == 0) {
+        if (Cutscene_IsCueInChannel(play, CS_CMD_ACTOR_CUE_518) &&
+            (play->csCtx.actorCues[Cutscene_GetCueChannel(play, CS_CMD_ACTOR_CUE_518)]->id != 1)) {
+            // @recomp During this cue the mask does nothing other than teleport offscreen and stay still,
+            // so we can just skip interpolation the entire time.
+            if (play->csCtx.actorCues[Cutscene_GetCueChannel(play, CS_CMD_ACTOR_CUE_518)]->id == 3) {
+                actor_set_interpolation_skipped(thisx);
+            }
+            Gfx_SetupDL25_Opa(play->state.gfxCtx);
+            SkelAnime_DrawFlexOpa(play, this->skelAnime.skeleton, this->skelAnime.jointTable,
+                                  this->skelAnime.dListCount, NULL, NULL, &this->actor);
+        }
+    } else if (this->unk_18E == 1) {
+        func_80AADF54(play, this);
+    }
 }


### PR DESCRIPTION
This PR fixes the interpolation glitch that used to occur when the Gibdo mask is meant to teleport offscreen during the cutscene with Pamela's dad. 