### PR TITLE
Fixed interpolation glitch with Gibdo mask in Pamela cutscene

### DIFF
--- a/patches/specific_actor_transform_tagging.c
+++ b/patches/specific_actor_transform_tagging.c
@@ -13,6 +13,7 @@
 #include "overlays/actors/ovl_En_Honotrap/z_en_honotrap.h"
 #include "overlays/actors/ovl_En_Tanron1/z_en_tanron1.h"
 #include "overlays/actors/ovl_En_Kusa2/z_en_kusa2.h"
+#include "overlays/actors/ovl_Dm_Char05/z_dm_char05.h"
 
 // Decomp renames, TODO update decomp and remove these
 #define EnHonotrap_FlameGroup func_8092F878
@@ -1372,4 +1373,27 @@ RECOMP_PATCH void func_80A5E6F0(Actor* thisx, PlayState* play) {
     }
 
     CLOSE_DISPS(play->state.gfxCtx);
+}
+
+extern void func_80AADF54(PlayState* play, DmChar05* this);
+
+// @recomp Patched to avoid an interpolation glitch in Pamela's dad's cutscene
+// that happens when the mask is meant to teleport offscreen.
+RECOMP_PATCH void func_80AADB4C(Actor* thisx, PlayState* play) {
+    DmChar05* this = (DmChar05*)thisx;
+    if (this->unk_18E == 0) {
+        if (Cutscene_IsCueInChannel(play, CS_CMD_ACTOR_CUE_518) &&
+            (play->csCtx.actorCues[Cutscene_GetCueChannel(play, CS_CMD_ACTOR_CUE_518)]->id != 1)) {
+            // @recomp During this cue the mask does nothing other than teleport offscreen and stay still,
+            // so we can just skip interpolation the entire time.
+            if (play->csCtx.actorCues[Cutscene_GetCueChannel(play, CS_CMD_ACTOR_CUE_518)]->id == 3) {
+                actor_set_interpolation_skipped(thisx);
+            }
+            Gfx_SetupDL25_Opa(play->state.gfxCtx);
+            SkelAnime_DrawFlexOpa(play, this->skelAnime.skeleton, this->skelAnime.jointTable,
+                                  this->skelAnime.dListCount, NULL, NULL, &this->actor);
+        }
+    } else if (this->unk_18E == 1) {
+        func_80AADF54(play, this);
+    }
 }


### PR DESCRIPTION
This PR fixes the interpolation glitch that used to occur when the Gibdo mask is meant to teleport offscreen during the cutscene with Pamela's dad.

<!--- section:artifacts:start -->
### Build Artifacts
- [Zelda64Recompiled-Linux-X64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/3674248057.zip)
- [Zelda64Recompiled-AppImage-X64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/3674248654.zip)
- [Zelda64Recompiled-Linux-X64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/3674248917.zip)
- [Zelda64Recompiled-AppImage-X64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/3674249488.zip)
- [Zelda64Recompiled-macOS-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/3674252859.zip)
- [Zelda64Recompiled-Windows-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/3674253684.zip)
- [Zelda64Recompiled-PDB-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/3674253818.zip)
- [Zelda64Recompiled-macOS-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/3674254392.zip)
- [Zelda64Recompiled-Windows-RelWithDebInfo.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/3674254459.zip)
- [Zelda64Recompiled-PDB-RelWithDebInfo.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/3674254560.zip)
- [Zelda64Recompiled-Linux-ARM64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/3674258824.zip)
- [Zelda64Recompiled-Linux-ARM64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/3674259406.zip)
- [Zelda64Recompiled-AppImage-ARM64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/3674259928.zip)
- [Zelda64Recompiled-AppImage-ARM64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/3674260536.zip)
- [Zelda64Recompiled-Flatpak-X64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/3674264459.zip)
- [Zelda64Recompiled-Flatpak-X64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/3674266755.zip)
<!--- section:artifacts:end -->