### PR TITLE
Autosave swamp cruise fix

### DIFF
--- a/patches/autosaving.c
+++ b/patches/autosaving.c
@@ -31,7 +31,8 @@ RECOMP_PATCH void KaleidoSetup_Update(PlayState* play) {
                 if (!Play_InCsMode(play) || ((msgCtx->msgMode != MSGMODE_NONE) && (msgCtx->currentTextId == 0xFF))) {
                     if ((play->unk_1887C < 2) && (gSaveContext.magicState != MAGIC_STATE_STEP_CAPACITY) &&
                         (gSaveContext.magicState != MAGIC_STATE_FILL)) {
-                        if (!CHECK_EVENTINF(EVENTINF_17) && !(player->stateFlags1 & PLAYER_STATE1_20) && !(CHECK_EVENTINF(EVENTINF_41))) {
+                        // @recomp Check game state to prevent autosaving during invalid states (day progression, mid cutscene, mid minigame, etc)
+                        if (!CHECK_EVENTINF(EVENTINF_17) && !(player->stateFlags1 & PLAYER_STATE1_20) && !(gSaveContext.minigameStatus == MINIGAME_STATUS_ACTIVE)) {
                             if (!(play->actorCtx.flags & ACTORCTX_FLAG_TELESCOPE_ON) &&
                                 !(play->actorCtx.flags & ACTORCTX_FLAG_PICTO_BOX_ON)) {
                                 if (!play->actorCtx.isOverrideInputOn) {

--- a/patches/autosaving.c
+++ b/patches/autosaving.c
@@ -629,6 +629,9 @@ RECOMP_PATCH void Sram_OpenSave(FileSelectState* fileSelect, SramContext* sramCt
     }
     // @recomp Handle autosaves.
     else if (gSaveContext.save.isOwlSave == SAVE_TYPE_AUTOSAVE) {
+        // Clear Rock Sirloin from being held, due to MM hardcoding its behavior
+        gSaveContext.unk_1014 = 0; 
+
         gSaveContext.save.entrance = spawn_entrance_from_autosave_entrance(gSaveContext.save.entrance);
 
         // Skip the turtle cutscene that happens when entering Great Bay Temple.
@@ -682,7 +685,6 @@ RECOMP_PATCH void Sram_OpenSave(FileSelectState* fileSelect, SramContext* sramCt
         fileNum = gSaveContext.fileNum;
         func_80147314(sramCtx, fileNum);
     }
-    gSaveContext.unk_1014 = 0; // Don't load with the Rock Sirloin in hand.
 
     // @recomp Initialize the autosave state tracking.
     autosave_init();

--- a/patches/autosaving.c
+++ b/patches/autosaving.c
@@ -410,7 +410,7 @@ void autosave_post_play_update(PlayState* play) {
 
         OSTime time_now = osGetTime();
 
-        // Check the following conditions for autsave safety:
+        // Check the following conditions for autosave safety:
         // * The UI is in a normal state.
         // * Time is passing.
         // * No message is on screen.

--- a/patches/autosaving.c
+++ b/patches/autosaving.c
@@ -31,8 +31,7 @@ RECOMP_PATCH void KaleidoSetup_Update(PlayState* play) {
                 if (!Play_InCsMode(play) || ((msgCtx->msgMode != MSGMODE_NONE) && (msgCtx->currentTextId == 0xFF))) {
                     if ((play->unk_1887C < 2) && (gSaveContext.magicState != MAGIC_STATE_STEP_CAPACITY) &&
                         (gSaveContext.magicState != MAGIC_STATE_FILL)) {
-                        // @recomp Check game state to prevent autosaving during invalid states (day progression, mid cutscene, mid minigame, etc)
-                        if (!CHECK_EVENTINF(EVENTINF_17) && !(player->stateFlags1 & PLAYER_STATE1_20) && !(gSaveContext.minigameStatus == MINIGAME_STATUS_ACTIVE)) {
+                        if (!CHECK_EVENTINF(EVENTINF_17) && !(player->stateFlags1 & PLAYER_STATE1_20)) {
                             if (!(play->actorCtx.flags & ACTORCTX_FLAG_TELESCOPE_ON) &&
                                 !(play->actorCtx.flags & ACTORCTX_FLAG_PICTO_BOX_ON)) {
                                 if (!play->actorCtx.isOverrideInputOn) {
@@ -411,7 +410,7 @@ void autosave_post_play_update(PlayState* play) {
 
         OSTime time_now = osGetTime();
 
-        // Check the following conditions:
+        // Check the following conditions for autsave safety:
         // * The UI is in a normal state.
         // * Time is passing.
         // * No message is on screen.
@@ -419,6 +418,10 @@ void autosave_post_play_update(PlayState* play) {
         // * No cutscene is running.
         // * The game is not in cutscene mode.
         // * The clock has not reached the final 3 hours.
+        // * The player is not in an active/inactive minigame (not all minigames use this flag, default is STATUS_END)
+        // * The player is not in a timed minigame in the first set (Shooting Gallery, Butler Race, Spirit House, etc)
+        // * The player is not in a timed minigame in the second set (Goron Race, Treasure Game, Beaver Bros, etc)
+        // * The player is not taking a boat cruise
         // * The player is allowed to pause.
         if (gSaveContext.hudVisibility == HUD_VISIBILITY_ALL &&
             R_TIME_SPEED != 0 &&
@@ -428,6 +431,10 @@ void autosave_post_play_update(PlayState* play) {
             gSaveContext.save.cutsceneIndex < 0xFFF0 &&
             !Play_InCsMode(play) &&
             !reached_final_three_hours() &&
+            gSaveContext.minigameStatus == MINIGAME_STATUS_END &&
+            gSaveContext.timerStates[TIMER_ID_MINIGAME_1] == TIMER_STATE_OFF &&
+            gSaveContext.timerStates[TIMER_ID_MINIGAME_2] == TIMER_STATE_OFF &&
+            !(CHECK_EVENTINF(EVENTINF_41)) &&
             gCanPause
         ) {
             frames_since_autosave_ready++;

--- a/patches/autosaving.c
+++ b/patches/autosaving.c
@@ -682,6 +682,7 @@ RECOMP_PATCH void Sram_OpenSave(FileSelectState* fileSelect, SramContext* sramCt
         fileNum = gSaveContext.fileNum;
         func_80147314(sramCtx, fileNum);
     }
+    gSaveContext.unk_1014 = 0; // Don't load with the Rock Sirloin in hand.
 
     // @recomp Initialize the autosave state tracking.
     autosave_init();

--- a/patches/autosaving.c
+++ b/patches/autosaving.c
@@ -31,7 +31,7 @@ RECOMP_PATCH void KaleidoSetup_Update(PlayState* play) {
                 if (!Play_InCsMode(play) || ((msgCtx->msgMode != MSGMODE_NONE) && (msgCtx->currentTextId == 0xFF))) {
                     if ((play->unk_1887C < 2) && (gSaveContext.magicState != MAGIC_STATE_STEP_CAPACITY) &&
                         (gSaveContext.magicState != MAGIC_STATE_FILL)) {
-                        if (!CHECK_EVENTINF(EVENTINF_17) && !(player->stateFlags1 & PLAYER_STATE1_20)) {
+                        if (!CHECK_EVENTINF(EVENTINF_17) && !(player->stateFlags1 & PLAYER_STATE1_20) && !(CHECK_EVENTINF(EVENTINF_41))) {
                             if (!(play->actorCtx.flags & ACTORCTX_FLAG_TELESCOPE_ON) &&
                                 !(play->actorCtx.flags & ACTORCTX_FLAG_PICTO_BOX_ON)) {
                                 if (!play->actorCtx.isOverrideInputOn) {
@@ -74,6 +74,10 @@ RECOMP_DECLARE_EVENT(recomp_on_autosave(PlayState* play));
 RECOMP_DECLARE_EVENT(recomp_after_autosave(PlayState* play));
 
 RECOMP_EXPORT void recomp_do_autosave(PlayState* play) {
+    // Tell console we are autosaving for debugging
+    recomp_printf("Triggering auto save at %d \n", gSaveContext.save.time);
+    //recomp_printf("Loaded entrance: %d in scene: %d\n", autosave_entrance, scene_id);
+
     // @recomp_event recomp_on_autosave(PlayState* play): Autosave triggered.
     recomp_on_autosave(play);
     // Transfer the scene flags into the cycle flags.

--- a/patches/autosaving.c
+++ b/patches/autosaving.c
@@ -74,9 +74,6 @@ RECOMP_DECLARE_EVENT(recomp_on_autosave(PlayState* play));
 RECOMP_DECLARE_EVENT(recomp_after_autosave(PlayState* play));
 
 RECOMP_EXPORT void recomp_do_autosave(PlayState* play) {
-    // Tell console we are autosaving for debugging
-    recomp_printf("Triggering auto save at %d \n", gSaveContext.save.time);
-    //recomp_printf("Loaded entrance: %d in scene: %d\n", autosave_entrance, scene_id);
 
     // @recomp_event recomp_on_autosave(PlayState* play): Autosave triggered.
     recomp_on_autosave(play);


### PR DESCRIPTION
Adding a CHECK_EVENTINF that prevents autosaving during the limited control state of the Swamp Cruise.

A more durable solution requires fully documented list of EVENTINF's, but that belongs upstream in MMDECOMP to my understanding.

A Debug menu tool where these flags can be set or viewed might be useful to complete this, assist modding, glitch finding, etc.  I'll look into that as well.

<!--- section:artifacts:start -->
### Build Artifacts
- [Zelda64Recompiled-Linux-X64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/3663512436.zip)
- [Zelda64Recompiled-AppImage-X64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/3663513413.zip)
- [Zelda64Recompiled-Linux-ARM64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/3663516672.zip)
- [Zelda64Recompiled-AppImage-ARM64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/3663518853.zip)
- [Zelda64Recompiled-Windows-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/3663526223.zip)
- [Zelda64Recompiled-PDB-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/3663526437.zip)
- [Zelda64Recompiled-Windows-RelWithDebInfo.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/3663531003.zip)
- [Zelda64Recompiled-PDB-RelWithDebInfo.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/3663531204.zip)
- [Zelda64Recompiled-Flatpak-X64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/3663534145.zip)
- [Zelda64Recompiled-Flatpak-X64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/3663534617.zip)
- [Zelda64Recompiled-Linux-X64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/3663538831.zip)
- [Zelda64Recompiled-AppImage-X64-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/3663539606.zip)
- [Zelda64Recompiled-Linux-ARM64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/3663544278.zip)
- [Zelda64Recompiled-AppImage-ARM64-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/3663546350.zip)
- [Zelda64Recompiled-macOS-Debug.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/3663555034.zip)
- [Zelda64Recompiled-macOS-Release.zip](https://nightly.link/Zelda64Recomp/Zelda64Recomp/actions/artifacts/3663559927.zip)
<!--- section:artifacts:end -->