### PR TITLE
Update RT64 to double refresh rate if interlacing is detected

### DIFF
--- a/patches/Makefile
+++ b/patches/Makefile
@@ -5,7 +5,7 @@ LD      ?= ld.lld
 
 CFLAGS   := -target mips -mips2 -mabi=32 -O2 -G0 -mno-abicalls -mno-odd-spreg -mno-check-zero-division \
 			-fomit-frame-pointer -ffast-math -fno-unsafe-math-optimizations -fno-builtin-memset \
-			-Wall -Wextra -Wno-incompatible-library-redeclaration -Wno-unused-parameter -Wno-unknown-pragmas -Wno-unused-variable -Wno-missing-braces -Wno-unsupported-floating-point-opt
+			-Wall -Wextra -Wno-incompatible-library-redeclaration -Wno-unused-parameter -Wno-unknown-pragmas -Wno-unused-variable -Wno-missing-braces -Wno-unsupported-floating-point-opt -Wno-error=incompatible-pointer-types
 CPPFLAGS := -nostdinc -D_LANGUAGE_C -DMIPS -I dummy_headers -I ../lib/mm-decomp/include -I ../lib/mm-decomp/src -I ../lib/mm-decomp/assets -I../lib/rt64/include
 LDFLAGS  := -nostdlib -T patches.ld -T syms.ld -Map patches.map --unresolved-symbols=ignore-all --emit-relocs
 

--- a/patches/camera_transform_tagging.c
+++ b/patches/camera_transform_tagging.c
@@ -221,7 +221,7 @@ RECOMP_PATCH void View_Apply(View* view, s32 mask) {
 
         // @recomp Determine if interpolation should occur based on the new eye and at positions.
         if (!camera_ignore_tracking) {
-            interpolate_camera = should_interpolate_perspective(&view->eye, &view->at); 
+            interpolate_camera = should_interpolate_perspective(&view->eye, &view->at);
         }
     }
     camera_ignore_tracking = false;

--- a/patches/camera_transform_tagging.c
+++ b/patches/camera_transform_tagging.c
@@ -221,7 +221,7 @@ RECOMP_PATCH void View_Apply(View* view, s32 mask) {
 
         // @recomp Determine if interpolation should occur based on the new eye and at positions.
         if (!camera_ignore_tracking) {
-            interpolate_camera = should_interpolate_perspective(&view->eye, &view->at);
+            interpolate_camera = should_interpolate_perspective(&view->eye, &view->at); 
         }
     }
     camera_ignore_tracking = false;


### PR DESCRIPTION
This change only applies to Windows.

In the future, we should research whether this change is needed on Linux at all (maybe SDL already deals with it) and figure it out if so.

Fixes #704 